### PR TITLE
Implements MFEMFESpaces, MFEMVariable, MFEMFECollections

### DIFF
--- a/include/fespaces/MFEMFECollection.h
+++ b/include/fespaces/MFEMFECollection.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "MFEMGeneralUserObject.h"
+#include "mfem.hpp"
+#include <string>
+
+/**
+ * Constructs and stores an mfem::FiniteElementCollection object. Access using
+ * the getFEC() accessor.
+ */
+class MFEMFECollection : public MFEMGeneralUserObject
+{
+public:
+  static InputParameters validParams();
+
+  MFEMFECollection(const InputParameters & parameters);
+
+  ~MFEMFECollection() override = default;
+
+  /// Returns a shared pointer to the constructed fec.
+  inline std::shared_ptr<mfem::FiniteElementCollection> getFEC() const { return _fec; }
+
+protected:
+  const int _fec_order;
+  const std::string _fec_type;
+  const std::string _fec_name;
+
+private:
+  /// Constructs the fec name from the order and fespace type.
+  const std::string buildFECName();
+
+  /// Constructs the fec from the fec name.
+  const std::shared_ptr<mfem::FiniteElementCollection> buildFEC();
+
+  /// Stores the constructed fec.
+  const std::shared_ptr<mfem::FiniteElementCollection> _fec{nullptr};
+};

--- a/include/fespaces/MFEMFESpace.h
+++ b/include/fespaces/MFEMFESpace.h
@@ -1,17 +1,38 @@
 #pragma once
 #include "MFEMGeneralUserObject.h"
+#include "MFEMFECollection.h"
 
+/**
+ * Constructs and stores an mfem::ParFiniteElementSpace object. Access using the
+ * getFESpace() accessor.
+ */
 class MFEMFESpace : public MFEMGeneralUserObject
 {
 public:
   static InputParameters validParams();
 
   MFEMFESpace(const InputParameters & parameters);
-  virtual ~MFEMFESpace();
 
-  static const std::string createFECName(const std::string & fespace_type, const int order);
-  const int order;
-  const int vdim;
-  const std::string fespace_type;
-  const std::string fec_name;
+  /// Returns a shared pointer to the constructed fespace.
+  inline std::shared_ptr<mfem::ParFiniteElementSpace> getFESpace() const { return _fespace; }
+
+  /// Returns a shared pointer to the constructed fec.
+  inline std::shared_ptr<mfem::FiniteElementCollection> getFEC() const { return _fec.getFEC(); }
+
+protected:
+  /// Vector dimension (number of unknowns per degree of freedom).
+  const int _vdim;
+
+  /// Type of ordering of the vector dofs when _vdim > 1.
+  const int _ordering;
+
+  /// Constructs and stores the fec.
+  const MFEMFECollection _fec;
+
+private:
+  /// Constructs the fespace.
+  const std::shared_ptr<mfem::ParFiniteElementSpace> buildFESpace();
+
+  /// Stores the constructed fespace.
+  const std::shared_ptr<mfem::ParFiniteElementSpace> _fespace{nullptr};
 };

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -125,13 +125,6 @@ public:
   void setMFEMVarData(const std::string & var_name);
   void setMOOSEVarData(const std::string & var_name);
 
-  /**
-   * Method used to get an mfem FEC depending on the variable family specified in the input file.
-   * This method is used in addAuxVariable to help create the MFEM grid function that corresponds to
-   * a given MOOSE aux-variable.
-   */
-  InputParameters addMFEMFESpaceFromMOOSEVariable(InputParameters & moosevar_params);
-
 protected:
   /**
    * Called internally by setMFEMVarData.

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -125,6 +125,13 @@ public:
   void setMFEMVarData(const std::string & var_name);
   void setMOOSEVarData(const std::string & var_name);
 
+  /**
+   * Method used to get an mfem FEC depending on the variable family specified in the input file.
+   * This method is used in addAuxVariable to help create the MFEM grid function that corresponds to
+   * a given MOOSE aux-variable.
+   */
+  InputParameters addMFEMFESpaceFromMOOSEVariable(InputParameters & moosevar_params);
+
 protected:
   /**
    * Called internally by setMFEMVarData.

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -172,6 +172,6 @@ protected:
 
   std::shared_ptr<platypus::ProblemBuilder> mfem_problem_builder{nullptr};
 
-  std::unique_ptr<platypus::Problem> mfem_problem{nullptr};
+  std::shared_ptr<platypus::Problem> mfem_problem{nullptr};
   std::unique_ptr<platypus::Executioner> executioner{nullptr};
 };

--- a/include/problem_builders/steady_state_equation_system_problem_builder.h
+++ b/include/problem_builders/steady_state_equation_system_problem_builder.h
@@ -56,8 +56,6 @@ public:
   /// equation system is initialized.
   void InitializeKernels() final;
 
-  auto ReturnProblem() { return ProblemBuilder::ReturnProblem<SteadyStateEquationSystemProblem>(); }
-
 protected:
   [[nodiscard]] platypus::SteadyStateEquationSystemProblem * GetProblem() const override
   {

--- a/include/problem_builders/steady_state_problem_builder.h
+++ b/include/problem_builders/steady_state_problem_builder.h
@@ -44,8 +44,6 @@ public:
 
   ~SteadyStateProblemBuilder() override = default;
 
-  auto ReturnProblem() { return ProblemBuilder::ReturnProblem<SteadyStateProblem>(); }
-
   void RegisterFESpaces() override {}
 
   void RegisterGridFunctions() override {}

--- a/include/problem_builders/time_domain_equation_system_problem_builder.h
+++ b/include/problem_builders/time_domain_equation_system_problem_builder.h
@@ -56,8 +56,6 @@ public:
   /// NB: - note use of final. Ensure that the equation system is initialized.
   void InitializeKernels() final;
 
-  auto ReturnProblem() { return ProblemBuilder::ReturnProblem<TimeDomainEquationSystemProblem>(); }
-
 protected:
   [[nodiscard]] platypus::TimeDomainEquationSystemProblem * GetProblem() const override
   {

--- a/include/problem_builders/time_domain_problem_builder.h
+++ b/include/problem_builders/time_domain_problem_builder.h
@@ -43,8 +43,6 @@ public:
 
   ~TimeDomainProblemBuilder() override = default;
 
-  auto ReturnProblem() { return ProblemBuilder::ReturnProblem<TimeDomainProblem>(); }
-
   static std::vector<mfem::ParGridFunction *>
   RegisterTimeDerivatives(std::vector<std::string> gridfunction_names,
                           platypus::GridFunctions & gridfunctions);

--- a/include/variables/MFEMVariable.h
+++ b/include/variables/MFEMVariable.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "MFEMFESpace.h"
-#include "MooseVariableBase.h"
+#include "MFEMGeneralUserObject.h"
 
 /**
  * Constructs and stores an mfem::ParGridFunction object.
  */
-class MFEMVariable : public MooseVariableBase
+class MFEMVariable : public MFEMGeneralUserObject
 {
 public:
   static InputParameters validParams();

--- a/include/variables/MFEMVariable.h
+++ b/include/variables/MFEMVariable.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "MFEMFESpace.h"
-#include "MFEMGeneralUserObject.h"
+#include "MooseVariableBase.h"
 
 /**
  * Constructs and stores an mfem::ParGridFunction object.
  */
-class MFEMVariable : public MFEMGeneralUserObject
+class MFEMVariable : public MooseVariableBase
 {
 public:
   static InputParameters validParams();

--- a/include/variables/MFEMVariable.h
+++ b/include/variables/MFEMVariable.h
@@ -3,14 +3,26 @@
 #include "MFEMFESpace.h"
 #include "MFEMGeneralUserObject.h"
 
+/**
+ * Constructs and stores an mfem::ParGridFunction object.
+ */
 class MFEMVariable : public MFEMGeneralUserObject
 {
 public:
   static InputParameters validParams();
 
   MFEMVariable(const InputParameters & parameters);
-  virtual ~MFEMVariable();
 
-  const MFEMFESpace & fespace;
-  unsigned int components;
+  /// Returns a shared pointer to the constructed gridfunction.
+  inline std::shared_ptr<mfem::ParGridFunction> getGridFunction() const { return _gridfunction; }
+
+protected:
+  const MFEMFESpace & _fespace;
+
+private:
+  /// Constructs the gridfunction.
+  const std::shared_ptr<mfem::ParGridFunction> buildGridFunction();
+
+  /// Stores the constructed gridfunction.
+  const std::shared_ptr<mfem::ParGridFunction> _gridfunction{nullptr};
 };

--- a/src/base/PlatypusApp.C
+++ b/src/base/PlatypusApp.C
@@ -53,9 +53,6 @@ associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
   addTaskDependency("add_aux_variable", "add_mfem_fespaces");
   addTaskDependency("add_elemental_field_variable", "add_mfem_fespaces");
   addTaskDependency("add_kernel", "add_mfem_fespaces");
-
-  // add aux variables.
-  appendMooseObjectTask("add_aux_variable", MFEMVariable);
 }
 
 void

--- a/src/base/PlatypusApp.C
+++ b/src/base/PlatypusApp.C
@@ -47,6 +47,7 @@ associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
 
   // add FESpaces
   registerMooseObjectTask("add_mfem_fespaces", MFEMFESpace, false);
+  appendMooseObjectTask("add_mfem_fespaces", MFEMFECollection);
   registerSyntaxTask("AddFESpaceAction", "FESpaces/*", "add_mfem_fespaces");
   addTaskDependency("add_variable", "add_mfem_fespaces");
   addTaskDependency("add_aux_variable", "add_mfem_fespaces");

--- a/src/base/PlatypusApp.C
+++ b/src/base/PlatypusApp.C
@@ -53,6 +53,9 @@ associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
   addTaskDependency("add_aux_variable", "add_mfem_fespaces");
   addTaskDependency("add_elemental_field_variable", "add_mfem_fespaces");
   addTaskDependency("add_kernel", "add_mfem_fespaces");
+
+  // add aux variables.
+  appendMooseObjectTask("add_aux_variable", MFEMVariable);
 }
 
 void

--- a/src/fespaces/MFEMFECollection.C
+++ b/src/fespaces/MFEMFECollection.C
@@ -1,0 +1,49 @@
+#include "MFEMFECollection.h"
+
+registerMooseObject("PlatypusApp", MFEMFECollection);
+
+InputParameters
+MFEMFECollection::validParams()
+{
+  InputParameters params = MFEMGeneralUserObject::validParams();
+  params.registerBase("MFEMFECollection");
+
+  MooseEnum fec_order(
+      "CONSTANT FIRST SECOND THIRD FOURTH FIFTH SIXTH SEVENTH EIGHTH NINTH TENTH ELEVENTH TWELFTH"
+      "THIRTEENTH FOURTEENTH FIFTEENTH SIXTEENTH SEVENTEENTH EIGHTTEENTH NINETEENTH TWENTIETH "
+      "TWENTYFIRST TWENTYSECOND TWENTYTHIRD TWENTYFOURTH TWENTYFIFTH TWENTYSIXTH TWENTYSEVENTH "
+      "TWENTYEIGHTH TWENTYNINTH THIRTIETH THIRTYFIRST THIRTYSECOND THIRTYTHIRD THIRTYFOURTH "
+      "THIRTYFIFTH THIRTYSIXTH THIRTYSEVENTH THIRTYEIGHTH THIRTYNINTH FORTIETH FORTYFIRST"
+      "FORTYSECOND FORTYTHIRD",
+      "FIRST",
+      true);
+  params.addParam<MooseEnum>("fec_order", fec_order, "Order of the FE shape function to use.");
+
+  MooseEnum fec_types("H1 ND RT L2", "H1", true);
+  params.addParam<MooseEnum>(
+      "fec_type", fec_types, "Specifies the family of FE shape functions (FE space).");
+
+  return params;
+}
+
+MFEMFECollection::MFEMFECollection(const InputParameters & parameters)
+  : MFEMGeneralUserObject(parameters),
+    _fec_order(parameters.get<MooseEnum>("fec_order")),
+    _fec_type(parameters.get<MooseEnum>("fec_type")),
+    _fec_name(buildFECName()),
+    _fec(buildFEC())
+{
+}
+
+const std::string
+MFEMFECollection::buildFECName()
+{
+  return _fec_type + "_3D_P" + std::to_string(_fec_order);
+}
+
+const std::shared_ptr<mfem::FiniteElementCollection>
+MFEMFECollection::buildFEC()
+{
+  auto * fec_ptr = mfem::FiniteElementCollection::New(_fec_name.c_str());
+  return std::shared_ptr<mfem::FiniteElementCollection>(fec_ptr);
+}

--- a/src/fespaces/MFEMFESpace.C
+++ b/src/fespaces/MFEMFESpace.C
@@ -1,4 +1,5 @@
 #include "MFEMFESpace.h"
+#include "MFEMProblem.h"
 
 registerMooseObject("PlatypusApp", MFEMFESpace);
 
@@ -7,42 +8,31 @@ MFEMFESpace::validParams()
 {
   InputParameters params = MFEMGeneralUserObject::validParams();
   params.registerBase("MFEMFESpace");
-  MooseEnum fespace_types("H1 ND RT L2", "H1", true);
-  params.addParam<MooseEnum>(
-      "fespace_type",
-      fespace_types,
-      "Specifies the family of FE shape functions (FE space) to use for this variable.");
-  MooseEnum order(
-      "CONSTANT FIRST SECOND THIRD FOURTH FIFTH SIXTH SEVENTH EIGHTH NINTH TENTH ELEVENTH TWELFTH"
-      "THIRTEENTH FOURTEENTH FIFTEENTH SIXTEENTH SEVENTEENTH EIGHTTEENTH NINETEENTH TWENTIETH "
-      "TWENTYFIRST TWENTYSECOND TWENTYTHIRD TWENTYFOURTH TWENTYFIFTH TWENTYSIXTH TWENTYSEVENTH "
-      "TWENTYEIGHTH TWENTYNINTH THIRTIETH THIRTYFIRST THIRTYSECOND THIRTYTHIRD THIRTYFOURTH "
-      "THIRTYFIFTH THIRTYSIXTH THIRTYSEVENTH THIRTYEIGHTH THIRTYNINTH FORTIETH FORTYFIRST"
-      "FORTYSECOND FORTYTHIRD",
-      "FIRST",
-      true);
-  params.addParam<MooseEnum>("order",
-                             order,
-                             "Order of the FE shape function to use for this variable (additional"
-                             "orders not listed here are allowed,"
-                             "depending on the family.");
+
   params.addParam<int>("vdim", 1, "Dimension of degrees of freedom");
+
+  MooseEnum ordering("NODES VDIM", "NODES", false);
+  params.addParam<MooseEnum>("ordering", ordering, "Type of ordering of the vector dofs.");
+
+  params += MFEMFECollection::validParams();
+
   return params;
 }
 
 MFEMFESpace::MFEMFESpace(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
-    order(parameters.get<MooseEnum>("order")),
-    vdim(parameters.get<int>("vdim")),
-    fespace_type(parameters.get<MooseEnum>("fespace_type")),
-    fec_name(createFECName(fespace_type, order))
+    _vdim(parameters.get<int>("vdim")),
+    _ordering(parameters.get<MooseEnum>("ordering")),
+    _fec(parameters),
+    _fespace(buildFESpace())
 {
 }
 
-const std::string
-MFEMFESpace::createFECName(const std::string & fespace_type, const int order)
+const std::shared_ptr<mfem::ParFiniteElementSpace>
+MFEMFESpace::buildFESpace()
 {
-  return fespace_type + "_3D_P" + std::to_string(order);
-}
+  mfem::ParMesh & pmesh = getMFEMProblem().mesh().getMFEMParMesh();
+  mfem::FiniteElementCollection & fec = *_fec.getFEC();
 
-MFEMFESpace::~MFEMFESpace() {}
+  return std::make_shared<mfem::ParFiniteElementSpace>(&pmesh, &fec, _vdim, _ordering);
+}

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -80,8 +80,6 @@ MFEMProblem::initialSetup()
       mooseError("Specified formulation does not support Transient executioners");
     }
 
-    mfem_problem = mfem_transient_problem_builder->ReturnProblem();
-
     exec_params.SetParam("StartTime", float(_moose_executioner->getStartTime()));
     exec_params.SetParam("TimeStep", float(dt()));
     exec_params.SetParam("EndTime", float(_moose_executioner->endTime()));
@@ -98,8 +96,6 @@ MFEMProblem::initialSetup()
     {
       mooseError("Specified formulation does not support Steady executioners");
     }
-
-    mfem_problem = mfem_steady_problem_builder->ReturnProblem();
 
     exec_params.SetParam("Problem",
                          static_cast<platypus::SteadyStateProblem *>(mfem_problem.get()));
@@ -149,6 +145,8 @@ MFEMProblem::setFormulation(const std::string & user_object_name,
 
   mfem_problem_builder->SetMesh(std::make_shared<mfem::ParMesh>(mfem_par_mesh));
   mfem_problem_builder->ConstructOperator();
+
+  mfem_problem = mfem_problem_builder->ReturnProblem();
 }
 
 void

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -216,12 +216,11 @@ MFEMProblem::addAuxVariable(const std::string & var_type,
                             const std::string & var_name,
                             InputParameters & parameters)
 {
-  mooseAssert(var_type == "MFEMVariable", "Only MFEMVariable types supported.");
-
   FEProblemBase::addUserObject(var_type, var_name, parameters);
-  MFEMVariable & var(getUserObject<MFEMVariable>(var_name));
+  MFEMVariable & mfem_variable(getUserObject<MFEMVariable>(var_name));
 
-  mfem_problem_builder->AddGridFunction(var_name, var.fespace.name());
+  // Register gridfunction.
+  mfem_problem->_gridfunctions.Register(var_name, mfem_variable.getGridFunction());
 }
 
 void

--- a/src/variables/MFEMVariable.C
+++ b/src/variables/MFEMVariable.C
@@ -6,37 +6,24 @@ registerMooseObject("PlatypusApp", MFEMVariable);
 InputParameters
 MFEMVariable::validParams()
 {
-  InputParameters params = MFEMGeneralUserObject::validParams();
-
-  params.registerBase("MooseVariableBase");
+  InputParameters params = MooseVariableBase::validParams();
 
   // Create user-facing 'boundary' input for restricting inheriting object to boundaries.
   params.addRequiredParam<UserObjectName>("fespace",
                                           "The finite element space this variable is defined on.");
 
-  // Remaining params are for compatibility with MOOSE AuxVariable interface.
-  params.addRangeCheckedParam<unsigned int>(
-      "components", 3, "components>0", "Number of components for an array variable");
+  // Set moose required parameters with dummy options since we never actually use them.
+  params.set<MooseEnum>("order") = "CONSTANT";
+  params.set<MooseEnum>("family") = "SCALAR";
 
-  params.addParam<std::vector<Real>>("scaling",
-                                     "Specifies a scaling factor to apply to this variable");
-  params.addParam<bool>("eigen", false, "True to make this variable an eigen variable");
-  params.addParam<bool>("fv", false, "True to make this variable a finite volume variable");
-  params.addParam<bool>("array",
-                        false,
-                        "True to make this variable a array variable regardless of number of "
-                        "components. If 'components' > 1, this will automatically be set to"
-                        "true.");
-  params.addParamNamesToGroup("scaling eigen", "Advanced");
-
-  params.addParam<bool>("use_dual", false, "True to use dual basis for Lagrange multipliers");
+  params.addClassDescription("Class for MFEM variables (gridfunctions).");
 
   return params;
 }
 
 MFEMVariable::MFEMVariable(const InputParameters & parameters)
-  : MFEMGeneralUserObject(parameters),
-    _fespace(getUserObject<MFEMFESpace>("fespace")),
+  : MooseVariableBase(parameters),
+    _fespace(parameters.get<MFEMFESpace>("fespace")),
     _gridfunction(buildGridFunction())
 {
 }

--- a/src/variables/MFEMVariable.C
+++ b/src/variables/MFEMVariable.C
@@ -1,4 +1,5 @@
 #include "MFEMVariable.h"
+#include "mfem.hpp"
 
 registerMooseObject("PlatypusApp", MFEMVariable);
 
@@ -9,12 +10,11 @@ MFEMVariable::validParams()
 
   params.registerBase("MooseVariableBase");
 
-  // Create user-facing 'boundary' input for restricting inheriting object to boundaries
-
+  // Create user-facing 'boundary' input for restricting inheriting object to boundaries.
   params.addRequiredParam<UserObjectName>("fespace",
                                           "The finite element space this variable is defined on.");
 
-  // Remaining params are for compatibility with MOOSE AuxVariable interface
+  // Remaining params are for compatibility with MOOSE AuxVariable interface.
   params.addRangeCheckedParam<unsigned int>(
       "components", 3, "components>0", "Number of components for an array variable");
 
@@ -36,9 +36,13 @@ MFEMVariable::validParams()
 
 MFEMVariable::MFEMVariable(const InputParameters & parameters)
   : MFEMGeneralUserObject(parameters),
-    fespace(getUserObject<MFEMFESpace>("fespace")),
-    components(parameters.get<unsigned int>("components"))
+    _fespace(getUserObject<MFEMFESpace>("fespace")),
+    _gridfunction(buildGridFunction())
 {
 }
 
-MFEMVariable::~MFEMVariable() {}
+const std::shared_ptr<mfem::ParGridFunction>
+MFEMVariable::buildGridFunction()
+{
+  return std::make_shared<mfem::ParGridFunction>(_fespace.getFESpace().get());
+}

--- a/src/variables/MFEMVariable.C
+++ b/src/variables/MFEMVariable.C
@@ -1,4 +1,5 @@
 #include "MFEMVariable.h"
+#include "MooseVariableBase.h"
 #include "mfem.hpp"
 
 registerMooseObject("PlatypusApp", MFEMVariable);
@@ -6,24 +7,24 @@ registerMooseObject("PlatypusApp", MFEMVariable);
 InputParameters
 MFEMVariable::validParams()
 {
-  InputParameters params = MooseVariableBase::validParams();
+  InputParameters params = MFEMGeneralUserObject::validParams();
 
   // Create user-facing 'boundary' input for restricting inheriting object to boundaries.
   params.addRequiredParam<UserObjectName>("fespace",
                                           "The finite element space this variable is defined on.");
 
-  // Set moose required parameters with dummy options since we never actually use them.
-  params.set<MooseEnum>("order") = "CONSTANT";
-  params.set<MooseEnum>("family") = "SCALAR";
+  // Require moose variable parameters (not used!)
+  params += MooseVariableBase::validParams();
 
   params.addClassDescription("Class for MFEM variables (gridfunctions).");
+  params.registerBase("MFEMVariable");
 
   return params;
 }
 
 MFEMVariable::MFEMVariable(const InputParameters & parameters)
-  : MooseVariableBase(parameters),
-    _fespace(parameters.get<MFEMFESpace>("fespace")),
+  : MFEMGeneralUserObject(parameters),
+    _fespace(getUserObject<MFEMFESpace>("fespace")),
     _gridfunction(buildGridFunction())
 {
 }

--- a/test/tests/unit/kernels/diffusion_mfem.i
+++ b/test/tests/unit/kernels/diffusion_mfem.i
@@ -13,10 +13,18 @@
   type = CustomFormulation
 []
 
+[FESpaces]
+  [mfem_fespace]
+    type = MFEMFESpace 
+    fec_order = FIRST 
+    fec_type = H1
+  []
+[]
+
 [AuxVariables]
   [mfem_diffused]
-    family = LAGRANGE
-    order = FIRST
+    type = MFEMVariable
+    fespace = mfem_fespace
   []
 []
 

--- a/test/tests/unit/kernels/diffusion_mfem.i
+++ b/test/tests/unit/kernels/diffusion_mfem.i
@@ -16,7 +16,7 @@
 [AuxVariables]
   [mfem_diffused]
     family = LAGRANGE
-    order = FIRST 
+    order = FIRST
   []
 []
 

--- a/test/tests/unit/kernels/diffusion_mfem.i
+++ b/test/tests/unit/kernels/diffusion_mfem.i
@@ -13,18 +13,10 @@
   type = CustomFormulation
 []
 
-[FESpaces]
-  [mfem_fespace]
-    type = MFEMFESpace 
-    fec_order = FIRST 
-    fec_type = H1
-  []
-[]
-
 [AuxVariables]
   [mfem_diffused]
-    type = MFEMVariable
-    fespace = mfem_fespace
+    family = LAGRANGE
+    order = FIRST 
   []
 []
 


### PR DESCRIPTION
- Implements MFEMFESpace, MFEMFECollection, MFEMVariable based on the UML diagram.
- ReturnProblem() method now returns a shared pointer to the "Problem" instance rather than returning a unique pointer. This ensures that the problem pointer is set earlier in MFEMProblem. This ensures that when the actions call public MFEMProblem methods the problem exists.
- Cleans-up addMFEMFESpaceFromMooseVariable.