### PR TITLE
Reduce super-linter version to 6.4.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: super-linter/super-linter/slim@v6.6.0
+        uses: super-linter/super-linter/slim@v6.4.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ANSIBLE: false


### PR DESCRIPTION
Currently, the lint workflow is failing on main following PR merge commits, with the error
`Failed to initialize GITHUB_BEFORE_SHA for a push event. Output: HEAD~20`

This PR is an attempt to resolve this error following the solution employed in comments in [super-linter issue 5453](https://github.com/super-linter/super-linter/issues/5453) by rolling the version of super-linter used back to v6.4.1.