### PR TITLE
Update super-linter version to 6.7.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: super-linter/super-linter/slim@v6.4.1
+        uses: super-linter/super-linter/slim@v6.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ANSIBLE: false


### PR DESCRIPTION
Second attempt to fix failed linting on main after PR merge commits. Appears to have resolved the issue for other projects using super-linter.