### PR TITLE
Make weekly CI builds run sequentially

### DIFF
--- a/.github/workflows/weekly_build.yml
+++ b/.github/workflows/weekly_build.yml
@@ -37,6 +37,8 @@ jobs:
 
   push-platypus-image-to-docker-hub:
     name: DockerPublishPlatypus
+    needs: push-platypus-deps-image-to-docker-hub
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Registers a dependency of the `platypus` build job on the `platypus-deps` job in order to make it run sequentially. Set `platypus` job to always run, even if `platypus-deps` fails.