### PR TITLE
Change to use official MFEM repo for Docker and Sapphire Rapids builds

### DIFF
--- a/docker/platypus-deps/Dockerfile
+++ b/docker/platypus-deps/Dockerfile
@@ -111,7 +111,7 @@ RUN export PETSC_DIR=/$WORKDIR/petsc
 
 # Build MFEM and common miniapp
 WORKDIR /$WORKDIR
-RUN git clone https://github.com/Heinrich-BR/mfem.git
+RUN git clone https://github.com/mfem/mfem.git
 WORKDIR /$WORKDIR/mfem 
 RUN git checkout master && mkdir build
 WORKDIR /$WORKDIR/mfem/build

--- a/scripts/build-platypus-csd3-sapphire.sh
+++ b/scripts/build-platypus-csd3-sapphire.sh
@@ -227,9 +227,9 @@ function build_gslib() {
 
 function build_mfem() {
     cd "$WORKDIR" || exit
-    git clone https://github.com/Heinrich-BR/mfem.git
+    git clone https://github.com/mfem/mfem.git
     cd mfem || exit
-    git checkout SubmeshBoundary
+    git checkout master
     sed -i "s | list | # list|g" "$WORKDIR"/mfem/config/cmake/modules/FindNetCDF.cmake
     mkdir build
     cd build || exit


### PR DESCRIPTION
Previously, the Platypus build scripts for Docker and for Sapphire Rapids nodes on CSD3 were using a fork of MFEM, due to this branch having fixes with issues with builds with GPU support and the range of necessary Exodus reader functionality upstream. These updates have now been merged into MFEM's master branch, and so we should now base our builds off of the official MFEM repository instead.