### PR TITLE
GPU segfault and activity fix

### DIFF
--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -147,7 +147,6 @@ protected:
   std::string _input_mesh;
   std::string _formulation_name;
   int _order;
-  mfem::Device _device;
 
   platypus::Coefficients _coefficients;
   platypus::InputParameters _solver_options;

--- a/include/problem_builders/problem_builder_base.h
+++ b/include/problem_builders/problem_builder_base.h
@@ -33,6 +33,7 @@ public:
   platypus::FESpaces _fespaces;
   platypus::GridFunctions _gridfunctions;
 
+  mfem::Device _device;
   MPI_Comm _comm;
   int _myid;
   int _num_procs;
@@ -63,6 +64,7 @@ public:
   void SetJacobianPreconditioner(std::shared_ptr<mfem::Solver> preconditioner);
   void SetJacobianSolver(std::shared_ptr<mfem::Solver> solver);
   void SetCoefficients(platypus::Coefficients & coefficients);
+  void SetDevice(const std::string & dev);
 
   void AddFESpace(std::string fespace_name,
                   std::string fec_name,

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -24,8 +24,6 @@ MFEMProblem::MFEMProblem(const InputParameters & params)
     _outputs(),
     _exec_params()
 {
-  _device.Configure(getParam<std::string>("device"));
-  _device.Print(std::cout);
 }
 
 MFEMProblem::~MFEMProblem() {}
@@ -146,6 +144,7 @@ MFEMProblem::setFormulation(const std::string & user_object_name,
 
   mfem_problem_builder = mfem_formulation->getProblemBuilder();
 
+  mfem_problem_builder->SetDevice(getParam<std::string>("device"));
   mfem_problem_builder->SetMesh(std::make_shared<mfem::ParMesh>(mfem_par_mesh));
   mfem_problem_builder->ConstructOperator();
 

--- a/src/problem_builders/problem_builder_base.C
+++ b/src/problem_builders/problem_builder_base.C
@@ -68,6 +68,13 @@ ProblemBuilder::SetCoefficients(platypus::Coefficients & coefficients)
 }
 
 void
+ProblemBuilder::SetDevice(const std::string & dev){
+
+  GetProblem()->_device.Configure(dev);
+  GetProblem()->_device.Print(std::cout);
+}
+
+void
 ProblemBuilder::AddFESpace(std::string fespace_name, std::string fec_name, int vdim, int ordering)
 {
   if (GetProblem()->_fespaces.Has(fespace_name))

--- a/src/problem_builders/problem_builder_base.C
+++ b/src/problem_builders/problem_builder_base.C
@@ -68,7 +68,8 @@ ProblemBuilder::SetCoefficients(platypus::Coefficients & coefficients)
 }
 
 void
-ProblemBuilder::SetDevice(const std::string & dev){
+ProblemBuilder::SetDevice(const std::string & dev)
+{
 
   GetProblem()->_device.Configure(dev);
   GetProblem()->_device.Print(std::cout);


### PR DESCRIPTION
This PR fixes the issue whereby the `diffusion` problem would end in a segfault due to Device pointers being deleted when `MFEMProblem` ran out of scope but still being known to `EquationSystem`, which would subsequently try to delete them again in its destructor. Now, the `Device` object is part of the `Problem` class and is set up by the `ProblemBuilder`.

In addition to this, changing the location of the `Device` object has returned the GPU usage to levels that we were seeing previously. There is significant device activity during the `externalSolve` stage.