### PR TITLE
Update curl curl test ParaView gold files following MFEM update to PVTU outputs

### DIFF
--- a/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000000/data.pvtu
+++ b/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000000/data.pvtu
@@ -10,7 +10,7 @@
 	<PDataArray type="UInt8"  Name="types"        NumberOfComponents="1" format="ascii"/>
 </PCells>
 <PPointData>
-<PDataArray type="Float64" Name="e_field" NumberOfComponents="3" format="ascii" />
+<PDataArray type="Float64" Name="e_field" NumberOfComponents="3" ComponentName0="0" ComponentName1="1" ComponentName2="2" format="ascii" />
 </PPointData>
 <PCellData>
 	<PDataArray type="Int32" Name="attribute" NumberOfComponents="1" format="ascii"/>

--- a/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000000/proc000000.vtu
+++ b/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000000/proc000000.vtu
@@ -5394,7 +5394,7 @@
 </DataArray>
 </CellData>
 <PointData >
-<DataArray type="Float64" Name="e_field" NumberOfComponents="3" format="ascii" >
+<DataArray type="Float64" Name="e_field" NumberOfComponents="3" ComponentName0="0" ComponentName1="1" ComponentName2="2" format="ascii" >
 0 0 0 
 0 0 0 
 0 0 0 

--- a/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000001/data.pvtu
+++ b/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000001/data.pvtu
@@ -10,7 +10,7 @@
 	<PDataArray type="UInt8"  Name="types"        NumberOfComponents="1" format="ascii"/>
 </PCells>
 <PPointData>
-<PDataArray type="Float64" Name="e_field" NumberOfComponents="3" format="ascii" />
+<PDataArray type="Float64" Name="e_field" NumberOfComponents="3" ComponentName0="0" ComponentName1="1" ComponentName2="2" format="ascii" />
 </PPointData>
 <PCellData>
 	<PDataArray type="Int32" Name="attribute" NumberOfComponents="1" format="ascii"/>

--- a/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000001/proc000000.vtu
+++ b/test/tests/kernels/gold/OutputData/CurlCurl/Run0/Cycle000001/proc000000.vtu
@@ -5394,7 +5394,7 @@
 </DataArray>
 </CellData>
 <PointData >
-<DataArray type="Float64" Name="e_field" NumberOfComponents="3" format="ascii" >
+<DataArray type="Float64" Name="e_field" NumberOfComponents="3" ComponentName0="0" ComponentName1="1" ComponentName2="2" format="ascii" >
 -8.97931843e-11 -8.97931843e-11 0 
 -8.97931843e-11 -8.97931843e-11 0.707106781 
 -0.707106781 -8.97931843e-11 0 


### PR DESCRIPTION
ParaView output files for MFEM now list components by index rather than as (X, Y, Z) following the merge of [MFEM PR #4405](https://github.com/mfem/mfem/pull/4405). 

As a result, Platypus ParaView files in regression tests containing vectors must be re-golded to prevent CI failures when using MFEM's master branch. 