### PR TITLE
Assembly Levels

### DIFF
--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -126,7 +126,7 @@ protected:
   std::vector<std::unique_ptr<mfem::ParGridFunction>> _xs;
   std::vector<std::unique_ptr<mfem::ParGridFunction>> _dxdts;
 
-  mfem::Array2D<mfem::HypreParMatrix *> _h_blocks;
+  mfem::Array2D<const mfem::HypreParMatrix *> _h_blocks;
 
   // Arrays to store kernels to act on each component of weak form. Named
   // according to test variable

--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -127,6 +127,9 @@ protected:
   std::vector<std::unique_ptr<mfem::ParGridFunction>> _dxdts;
 
   mfem::Array2D<const mfem::HypreParMatrix *> _h_blocks;
+  
+  // Auxiliary operator for non-legacy assembly 
+  mfem::OperatorPtr aux_a;
 
   // Arrays to store kernels to act on each component of weak form. Named
   // according to test variable

--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -65,7 +65,8 @@ public:
   // Build forms
   virtual void Init(platypus::GridFunctions & gridfunctions,
                     const platypus::FESpaces & fespaces,
-                    platypus::BCMap & bc_map);
+                    platypus::BCMap & bc_map,
+                    mfem::AssemblyLevel assembly_level);
   virtual void BuildLinearForms(platypus::BCMap & bc_map);
   virtual void BuildBilinearForms();
   virtual void BuildMixedBilinearForms();
@@ -75,6 +76,14 @@ public:
   virtual void FormLinearSystem(mfem::OperatorHandle & op,
                                 mfem::BlockVector & trueX,
                                 mfem::BlockVector & trueRHS);
+
+  virtual void FormSystem(mfem::OperatorHandle & op,
+                                mfem::BlockVector & trueX,
+                                mfem::BlockVector & trueRHS);
+  virtual void FormLegacySystem(mfem::OperatorHandle & op,
+                                mfem::BlockVector & trueX,
+                                mfem::BlockVector & trueRHS);
+
 
   // Build linear system, with essential boundary conditions accounted for
   virtual void BuildJacobian(mfem::BlockVector & trueX, mfem::BlockVector & trueRHS);
@@ -132,6 +141,8 @@ protected:
       _mblf_kernels_map_map;
 
   mutable mfem::OperatorHandle _jacobian;
+
+  mfem::AssemblyLevel _assembly_level;
 };
 
 /*
@@ -158,7 +169,7 @@ public:
   virtual void AddKernel(const std::string & test_var_name,
                          std::shared_ptr<MFEMBilinearFormKernel> blf_kernel) override;
   virtual void BuildBilinearForms() override;
-  virtual void FormLinearSystem(mfem::OperatorHandle & op,
+  virtual void FormLegacySystem(mfem::OperatorHandle & op,
                                 mfem::BlockVector & truedXdt,
                                 mfem::BlockVector & trueRHS) override;
 };

--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -128,9 +128,6 @@ protected:
 
   mfem::Array2D<const mfem::HypreParMatrix *> _h_blocks;
   
-  // Auxiliary operator for non-legacy assembly 
-  mfem::OperatorPtr aux_a;
-
   // Arrays to store kernels to act on each component of weak form. Named
   // according to test variable
   platypus::NamedFieldsMap<std::vector<std::shared_ptr<MFEMBilinearFormKernel>>> _blf_kernels_map;
@@ -175,6 +172,10 @@ public:
   virtual void FormLegacySystem(mfem::OperatorHandle & op,
                                 mfem::BlockVector & truedXdt,
                                 mfem::BlockVector & trueRHS) override;
+  virtual void FormSystem(mfem::OperatorHandle & op,
+                                mfem::BlockVector & truedXdt,
+                                mfem::BlockVector & trueRHS) override;
+
 };
 
 } // namespace platypus

--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -77,13 +77,11 @@ public:
                                 mfem::BlockVector & trueX,
                                 mfem::BlockVector & trueRHS);
 
-  virtual void FormSystem(mfem::OperatorHandle & op,
-                                mfem::BlockVector & trueX,
-                                mfem::BlockVector & trueRHS);
+  virtual void
+  FormSystem(mfem::OperatorHandle & op, mfem::BlockVector & trueX, mfem::BlockVector & trueRHS);
   virtual void FormLegacySystem(mfem::OperatorHandle & op,
                                 mfem::BlockVector & trueX,
                                 mfem::BlockVector & trueRHS);
-
 
   // Build linear system, with essential boundary conditions accounted for
   virtual void BuildJacobian(mfem::BlockVector & trueX, mfem::BlockVector & trueRHS);
@@ -127,7 +125,7 @@ protected:
   std::vector<std::unique_ptr<mfem::ParGridFunction>> _dxdts;
 
   mfem::Array2D<const mfem::HypreParMatrix *> _h_blocks;
-  
+
   // Arrays to store kernels to act on each component of weak form. Named
   // according to test variable
   platypus::NamedFieldsMap<std::vector<std::shared_ptr<MFEMBilinearFormKernel>>> _blf_kernels_map;
@@ -173,9 +171,8 @@ public:
                                 mfem::BlockVector & truedXdt,
                                 mfem::BlockVector & trueRHS) override;
   virtual void FormSystem(mfem::OperatorHandle & op,
-                                mfem::BlockVector & truedXdt,
-                                mfem::BlockVector & trueRHS) override;
-
+                          mfem::BlockVector & truedXdt,
+                          mfem::BlockVector & trueRHS) override;
 };
 
 } // namespace platypus

--- a/include/named_fields_map/named_fields_map.h
+++ b/include/named_fields_map/named_fields_map.h
@@ -102,6 +102,9 @@ public:
   // NOLINTNEXTLINE(readability-identifier-naming)
   [[nodiscard]] inline const_iterator end() const { return _field_map.end(); }
 
+  // Returns the number of elements in the map
+  int size() { return _field_map.size(); }
+
 protected:
   /// Returns a const iterator to the field.
   [[nodiscard]] inline const_iterator FindField(const std::string & field_name) const

--- a/include/problem/MFEMProblem.h
+++ b/include/problem/MFEMProblem.h
@@ -41,6 +41,8 @@ public:
 
   virtual void syncSolutions(Direction direction) override{};
 
+  void setAssemblyLevel();
+
   /**
    * Overwritten mesh() method from base MooseMesh to retrieve the correct mesh type, in this case
    * MFEMMesh.

--- a/include/problem_builders/problem_builder_base.h
+++ b/include/problem_builders/problem_builder_base.h
@@ -32,6 +32,7 @@ public:
   platypus::FECollections _fecs;
   platypus::FESpaces _fespaces;
   platypus::GridFunctions _gridfunctions;
+  mfem::AssemblyLevel _assembly_level;
 
   mfem::Device _device;
   MPI_Comm _comm;

--- a/include/solvers/MFEMCGSolver.h
+++ b/include/solvers/MFEMCGSolver.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "MFEMSolverBase.h"
+#include "mfem.hpp"
+#include <memory>
+
+/**
+ * Wrapper for mfem::HyprePCG solver.
+ */
+class MFEMCGSolver : public MFEMSolverBase
+{
+public:
+  static InputParameters validParams();
+
+  MFEMCGSolver(const InputParameters & parameters);
+
+  /// Returns a shared pointer to the instance of the Solver derived-class.
+  std::shared_ptr<mfem::Solver> getSolver() const override { return _solver; }
+
+protected:
+  void constructSolver(const InputParameters & parameters) override;
+
+private:
+  std::shared_ptr<mfem::Solver> _preconditioner{nullptr};
+  std::shared_ptr<mfem::CGSolver> _solver{nullptr};
+};

--- a/include/solvers/MFEMGMRESSolver.h
+++ b/include/solvers/MFEMGMRESSolver.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "MFEMSolverBase.h"
+#include "mfem.hpp"
+#include <memory>
+
+/**
+ * Wrapper for mfem::HyprePCG solver.
+ */
+class MFEMGMRESSolver : public MFEMSolverBase
+{
+public:
+  static InputParameters validParams();
+
+  MFEMGMRESSolver(const InputParameters & parameters);
+
+  /// Returns a shared pointer to the instance of the Solver derived-class.
+  std::shared_ptr<mfem::Solver> getSolver() const override { return _solver; }
+
+protected:
+  void constructSolver(const InputParameters & parameters) override;
+
+private:
+  std::shared_ptr<mfem::Solver> _preconditioner{nullptr};
+  std::shared_ptr<mfem::GMRESSolver> _solver{nullptr};
+};

--- a/src/equation_systems/equation_system.C
+++ b/src/equation_systems/equation_system.C
@@ -112,6 +112,7 @@ EquationSystem::FormLinearSystem(mfem::OperatorHandle & op,
                            mfem::BlockVector & trueX,
                            mfem::BlockVector & trueRHS)
 {
+
   if(_assembly_level == mfem::AssemblyLevel::LEGACY)
   {
     FormLegacySystem(op, trueX, trueRHS);
@@ -131,21 +132,18 @@ EquationSystem::FormSystem(mfem::OperatorHandle & op,
                            mfem::BlockVector & trueRHS)
 {
 
-  mfem::OperatorPtr aux_a;
-  // Form diagonal blocks.
-  for (int i = 0; i < _test_var_names.size(); i++)
-  {
-    auto & test_var_name = _test_var_names.at(i);
-    auto blf = _blfs.Get(test_var_name);
-    auto lf = _lfs.Get(test_var_name);
-    mfem::Vector aux_x, aux_rhs;
-    blf->FormLinearSystem(
-        _ess_tdof_lists.at(i), *(_xs.at(i)), *lf, aux_a, aux_x, aux_rhs);
-    trueX.GetBlock(i) = aux_x;
-    trueRHS.GetBlock(i) = aux_rhs;
-  }
+  auto & test_var_name = _test_var_names.at(0);
+  auto blf = _blfs.Get(test_var_name);
+  auto lf = _lfs.Get(test_var_name);
+  mfem::Vector aux_x, aux_rhs;
+  
+  blf->FormLinearSystem(
+      _ess_tdof_lists.at(0), *(_xs.at(0)), *lf, aux_a, aux_x, aux_rhs);
+  trueX.GetBlock(0) = aux_x;
+  trueRHS.GetBlock(0) = aux_rhs;
 
-  op.Reset(aux_a.Ptr());
+  //op.Reset(aux_a.Ptr(), false);
+  op = aux_a;
 
 }
 
@@ -317,6 +315,7 @@ EquationSystem::BuildBilinearForms()
 
       for (auto & blf_kernel : blf_kernels)
       {
+        blf->SetAssemblyLevel(_assembly_level);
         blf->AddDomainIntegrator(blf_kernel->createIntegrator());
       }
     }

--- a/src/equation_systems/equation_system.C
+++ b/src/equation_systems/equation_system.C
@@ -109,23 +109,22 @@ EquationSystem::ApplyBoundaryConditions(platypus::BCMap & bc_map)
 
 void
 EquationSystem::FormLinearSystem(mfem::OperatorHandle & op,
-                           mfem::BlockVector & trueX,
-                           mfem::BlockVector & trueRHS)
+                                 mfem::BlockVector & trueX,
+                                 mfem::BlockVector & trueRHS)
 {
 
-  if(_assembly_level == mfem::AssemblyLevel::LEGACY)
+  if (_assembly_level == mfem::AssemblyLevel::LEGACY)
   {
     FormLegacySystem(op, trueX, trueRHS);
   }
   else
   {
-    MFEM_VERIFY(_test_var_names.size() == 1, "Non-legacy assembly is only supported for single-variable systems");
+    MFEM_VERIFY(_test_var_names.size() == 1,
+                "Non-legacy assembly is only supported for single-variable systems");
     MFEM_VERIFY(_mblfs.size() != 0, "Non-legacy assembly is only supported for square systems");
     FormSystem(op, trueX, trueRHS);
   }
-      
 }
-
 
 void
 EquationSystem::FormSystem(mfem::OperatorHandle & op,
@@ -137,17 +136,15 @@ EquationSystem::FormSystem(mfem::OperatorHandle & op,
   auto lf = _lfs.Get(test_var_name);
   mfem::BlockVector aux_x, aux_rhs;
   mfem::OperatorPtr * aux_a = new mfem::OperatorPtr;
-  
-  blf->FormLinearSystem(
-      _ess_tdof_lists.at(0), *(_xs.at(0)), *lf, *aux_a, aux_x, aux_rhs);
-  
+
+  blf->FormLinearSystem(_ess_tdof_lists.at(0), *(_xs.at(0)), *lf, *aux_a, aux_x, aux_rhs);
+
   trueX.GetBlock(0) = aux_x;
   trueRHS.GetBlock(0) = aux_rhs;
   trueX.SyncFromBlocks();
   trueRHS.SyncFromBlocks();
 
   op.Reset(aux_a->Ptr());
-
 }
 
 void
@@ -167,8 +164,7 @@ EquationSystem::FormLegacySystem(mfem::OperatorHandle & op,
     auto lf = _lfs.Get(test_var_name);
     mfem::Vector aux_x, aux_rhs;
     mfem::HypreParMatrix aux_a;
-    blf->FormLinearSystem(
-        _ess_tdof_lists.at(i), *(_xs.at(i)), *lf, aux_a, aux_x, aux_rhs);
+    blf->FormLinearSystem(_ess_tdof_lists.at(i), *(_xs.at(i)), *lf, aux_a, aux_x, aux_rhs);
     _h_blocks(i, i) = new const mfem::HypreParMatrix(aux_a);
     trueX.GetBlock(i) = aux_x;
     trueRHS.GetBlock(i) = aux_rhs;
@@ -500,8 +496,8 @@ TimeDependentEquationSystem::FormLegacySystem(mfem::OperatorHandle & op,
 
 void
 TimeDependentEquationSystem::FormSystem(mfem::OperatorHandle & op,
-                                              mfem::BlockVector & truedXdt,
-                                              mfem::BlockVector & trueRHS)
+                                        mfem::BlockVector & truedXdt,
+                                        mfem::BlockVector & trueRHS)
 {
   MFEM_VERIFY(0, "Non-legacy assembly not yet implemented for time-dependent systems");
 }

--- a/src/equation_systems/equation_system.C
+++ b/src/equation_systems/equation_system.C
@@ -120,6 +120,7 @@ EquationSystem::FormLinearSystem(mfem::OperatorHandle & op,
   else
   {
     MFEM_VERIFY(_test_var_names.size() == 1, "Non-legacy assembly is only supported for single-variable systems");
+    MFEM_VERIFY(_mblfs.size() != 0, "Non-legacy assembly is only supported for square systems");
     FormSystem(op, trueX, trueRHS);
   }
       

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -60,6 +60,8 @@ MFEMProblem::initialSetup()
   FEProblemBase::initialSetup();
   _coefficients.AddGlobalCoefficientsFromSubdomains();
 
+  setAssemblyLevel();
+
   mfem_problem_builder->SetCoefficients(_coefficients);
 
   // NB: set to false to avoid reconstructing problem operator.

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -16,7 +16,6 @@ MFEMProblem::validParams()
   params.addParam<std::string>(
       "assembly_level", "legacy", "Matrix assembly level. Options: Legacy, Full, Partial, Element");
 
-
   return params;
 }
 

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -13,6 +13,9 @@ MFEMProblem::validParams()
   params.addParam<bool>(
       "use_glvis", false, "Attempt to open GLVis ports to display variables during simulation");
   params.addParam<std::string>("device", "cpu", "Run app on the chosen device.");
+  params.addParam<std::string>(
+      "assembly_level", "legacy", "Matrix assembly level. Options: Legacy, Full, Partial, Element");
+
 
   return params;
 }
@@ -108,6 +111,26 @@ void
 MFEMProblem::init()
 {
   FEProblemBase::init();
+}
+
+void
+MFEMProblem::setAssemblyLevel()
+{
+  // Convert to lowercase string
+  std::string assembly = "";
+  for (auto c : getParam<std::string>("assembly_level"))
+    assembly += tolower(c);
+
+  if (assembly == "legacy")
+    mfem_problem->_assembly_level = mfem::AssemblyLevel::LEGACY;
+  else if (assembly == "full")
+    mfem_problem->_assembly_level = mfem::AssemblyLevel::FULL;
+  else if (assembly == "partial")
+    mfem_problem->_assembly_level = mfem::AssemblyLevel::PARTIAL;
+  else if (assembly == "element")
+    mfem_problem->_assembly_level = mfem::AssemblyLevel::ELEMENT;
+  else
+    MFEM_ABORT("Assembly level not recognised.");
 }
 
 void

--- a/src/problem_builders/steady_state_equation_system_problem_builder.C
+++ b/src/problem_builders/steady_state_equation_system_problem_builder.C
@@ -9,7 +9,7 @@ SteadyStateEquationSystemProblemBuilder::InitializeKernels()
   ProblemBuilder::InitializeKernels();
 
   GetEquationSystem()->Init(
-      GetProblem()->_gridfunctions, GetProblem()->_fespaces, GetProblem()->_bc_map);
+      GetProblem()->_gridfunctions, GetProblem()->_fespaces, GetProblem()->_bc_map, GetProblem()->_assembly_level);
 }
 
 } // namespace platypus

--- a/src/problem_builders/steady_state_equation_system_problem_builder.C
+++ b/src/problem_builders/steady_state_equation_system_problem_builder.C
@@ -8,8 +8,10 @@ SteadyStateEquationSystemProblemBuilder::InitializeKernels()
 {
   ProblemBuilder::InitializeKernels();
 
-  GetEquationSystem()->Init(
-      GetProblem()->_gridfunctions, GetProblem()->_fespaces, GetProblem()->_bc_map, GetProblem()->_assembly_level);
+  GetEquationSystem()->Init(GetProblem()->_gridfunctions,
+                            GetProblem()->_fespaces,
+                            GetProblem()->_bc_map,
+                            GetProblem()->_assembly_level);
 }
 
 } // namespace platypus

--- a/src/problem_builders/time_domain_equation_system_problem_builder.C
+++ b/src/problem_builders/time_domain_equation_system_problem_builder.C
@@ -8,8 +8,10 @@ TimeDomainEquationSystemProblemBuilder::InitializeKernels()
 {
   ProblemBuilder::InitializeKernels();
 
-  GetEquationSystem()->Init(
-      GetProblem()->_gridfunctions, GetProblem()->_fespaces, GetProblem()->_bc_map, GetProblem()->_assembly_level);
+  GetEquationSystem()->Init(GetProblem()->_gridfunctions,
+                            GetProblem()->_fespaces,
+                            GetProblem()->_bc_map,
+                            GetProblem()->_assembly_level);
 }
 
 } // namespace platypus

--- a/src/problem_builders/time_domain_equation_system_problem_builder.C
+++ b/src/problem_builders/time_domain_equation_system_problem_builder.C
@@ -9,7 +9,7 @@ TimeDomainEquationSystemProblemBuilder::InitializeKernels()
   ProblemBuilder::InitializeKernels();
 
   GetEquationSystem()->Init(
-      GetProblem()->_gridfunctions, GetProblem()->_fespaces, GetProblem()->_bc_map);
+      GetProblem()->_gridfunctions, GetProblem()->_fespaces, GetProblem()->_bc_map, GetProblem()->_assembly_level);
 }
 
 } // namespace platypus

--- a/src/solvers/MFEMCGSolver.C
+++ b/src/solvers/MFEMCGSolver.C
@@ -1,0 +1,43 @@
+#pragma once
+#include "MFEMCGSolver.h"
+#include "MFEMProblem.h"
+
+registerMooseObject("PlatypusApp", MFEMCGSolver);
+
+InputParameters
+MFEMCGSolver::validParams()
+{
+  InputParameters params = MFEMSolverBase::validParams();
+
+  params.addParam<double>("l_tol", 1e-5, "Set the relative tolerance.");
+  params.addParam<double>("l_abs_tol", 1e-50, "Set the absolute tolerance.");
+  params.addParam<int>("l_max_its", 10000, "Set the maximum number of iterations.");
+  params.addParam<int>("print_level", 2, "Set the solver verbosity.");
+  params.addParam<UserObjectName>("preconditioner", "Optional choice of preconditioner to use.");
+
+  return params;
+}
+
+MFEMCGSolver::MFEMCGSolver(const InputParameters & parameters)
+  : MFEMSolverBase(parameters),
+    _preconditioner(isParamSetByUser("preconditioner")
+                        ? getUserObject<MFEMSolverBase>("preconditioner").getSolver()
+                        : nullptr)
+{
+  constructSolver(parameters);
+}
+
+void
+MFEMCGSolver::constructSolver(const InputParameters & parameters)
+{
+  auto preconditioner = std::dynamic_pointer_cast<mfem::Solver>(_preconditioner);
+
+  _solver = std::make_shared<mfem::CGSolver>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
+  _solver->SetRelTol(getParam<double>("l_tol"));
+  _solver->SetAbsTol(getParam<double>("l_abs_tol"));
+  _solver->SetMaxIter(getParam<int>("l_max_its"));
+  _solver->SetPrintLevel(getParam<int>("print_level"));
+
+  if (preconditioner)
+    _solver->SetPreconditioner(*preconditioner);
+}

--- a/src/solvers/MFEMGMRESSolver.C
+++ b/src/solvers/MFEMGMRESSolver.C
@@ -1,0 +1,43 @@
+#pragma once
+#include "MFEMGMRESSolver.h"
+#include "MFEMProblem.h"
+
+registerMooseObject("PlatypusApp", MFEMGMRESSolver);
+
+InputParameters
+MFEMGMRESSolver::validParams()
+{
+  InputParameters params = MFEMSolverBase::validParams();
+
+  params.addParam<double>("l_tol", 1e-5, "Set the relative tolerance.");
+  params.addParam<double>("l_abs_tol", 1e-50, "Set the absolute tolerance.");
+  params.addParam<int>("l_max_its", 10000, "Set the maximum number of iterations.");
+  params.addParam<int>("print_level", 2, "Set the solver verbosity.");
+  params.addParam<UserObjectName>("preconditioner", "Optional choice of preconditioner to use.");
+
+  return params;
+}
+
+MFEMGMRESSolver::MFEMGMRESSolver(const InputParameters & parameters)
+  : MFEMSolverBase(parameters),
+    _preconditioner(isParamSetByUser("preconditioner")
+                        ? getUserObject<MFEMSolverBase>("preconditioner").getSolver()
+                        : nullptr)
+{
+  constructSolver(parameters);
+}
+
+void
+MFEMGMRESSolver::constructSolver(const InputParameters & parameters)
+{
+  auto preconditioner = std::dynamic_pointer_cast<mfem::Solver>(_preconditioner);
+
+  _solver = std::make_shared<mfem::GMRESSolver>(getMFEMProblem().mesh().getMFEMParMesh().GetComm());
+  _solver->SetRelTol(getParam<double>("l_tol"));
+  _solver->SetAbsTol(getParam<double>("l_abs_tol"));
+  _solver->SetMaxIter(getParam<int>("l_max_its"));
+  _solver->SetPrintLevel(getParam<int>("print_level"));
+
+  if (preconditioner)
+    _solver->SetPreconditioner(*preconditioner);
+}

--- a/test/tests/kernels/diffusion_partial.i
+++ b/test/tests/kernels/diffusion_partial.i
@@ -6,7 +6,7 @@
 
 [Problem]
   type = MFEMProblem
-  device = cpu
+  device = cuda
   assembly_level = partial
 []
 

--- a/test/tests/kernels/diffusion_partial.i
+++ b/test/tests/kernels/diffusion_partial.i
@@ -7,6 +7,7 @@
 [Problem]
   type = MFEMProblem
   device = cpu
+  assembly_level = partial
 []
 
 [FESpaces]
@@ -78,16 +79,18 @@
 []
 
 [Preconditioner]
-  [boomeramg]
-    type = MFEMHypreBoomerAMG
+  [cg]
+    type = MFEMCGSolver
+    print_level = 2
   []
 []
 
 [Solver]
-  type = MFEMHypreGMRES
-  preconditioner = boomeramg
+  type = MFEMCGSolver
+  preconditioner = cg
   l_tol = 1e-16
-  l_max_its = 1000  
+  l_max_its = 1000
+  print_level = 2
 []
 
 [Executioner]

--- a/test/tests/kernels/tests
+++ b/test/tests/kernels/tests
@@ -14,6 +14,13 @@
                 OutputData/Diffusion/Run0/Cycle000001/proc000000.vtu'
     requirement = 'Platypus shall have the ability to solve a diffusion problem set up from MOOSE and produce the same result as a native run.'
   []
+  [./MFEMDiffusionPartial]
+  type = XMLDiff
+  input = diffusion_partial.i
+  xmldiff = 'OutputData/Diffusion/Run0/Run0.pvd
+              OutputData/Diffusion/Run0/Cycle000001/proc000000.vtu'
+  requirement = 'Platypus shall have the ability to solve a diffusion problem with partial assembly set up from MOOSE and produce the same result as a native run.'
+  []
   [./MFEMHeatConduction]
     type = XMLDiff
     input = heatconduction.i


### PR DESCRIPTION
This PR introduces the possibility of choosing different `BilinearForm` assembly levels, both for CPU and GPU runs. A new diffusion test which verifies partial assembly on CPU has also been created.

Currently, non-legacy assembly is only supported for static, square, single-block systems. Future PRs will address each of these other cases.