### PR TITLE
Copy shared pointer to ParMesh rather than copying mesh

### DIFF
--- a/include/mesh/MFEMMesh.h
+++ b/include/mesh/MFEMMesh.h
@@ -35,6 +35,11 @@ public:
   mfem::ParMesh & getMFEMParMesh() { return *_mfem_par_mesh; };
 
   /**
+   * Copy a shared_ptr to the mfem::ParMesh object.
+   */
+  std::shared_ptr<mfem::ParMesh> getMFEMParMeshPtr() { return _mfem_par_mesh; };
+
+  /**
    * Build MFEM ParMesh and a placeholder MOOSE mesh.
    */
   void buildMesh() override;

--- a/src/problem/MFEMProblem.C
+++ b/src/problem/MFEMProblem.C
@@ -22,7 +22,7 @@ MFEMProblem::initialSetup()
 void
 MFEMProblem::setMesh()
 {
-  auto pmesh = std::make_shared<mfem::ParMesh>(mesh().getMFEMParMesh());
+  auto pmesh = mesh().getMFEMParMeshPtr();
   getProblemData()._pmesh = pmesh;
   getProblemData()._comm = pmesh->GetComm();
   MPI_Comm_size(pmesh->GetComm(), &(getProblemData()._num_procs));


### PR DESCRIPTION
Fixes accidental copy-construction.