### PR TITLE
Spack python fix

### DIFF
--- a/scripts/build-platypus-csd3-ampere.sh
+++ b/scripts/build-platypus-csd3-ampere.sh
@@ -113,6 +113,9 @@ install_spack_deps() {
 
     echo "Adding python modules..."
 
+    spack install python@3.12.5
+    spack load python@3.12.5 arch=${ARCH}
+
     spack install py-pyaml
     spack load py-pyaml arch=${ARCH}
 


### PR DESCRIPTION
This PR fixes an issue with the ampere build script where the MOOSE build crashes due to spack automatically using the latest version of the python package (3.13.0). This version seems to not be compatible with some parts of our build and even with other spack packages like `py-pre-commit`. Instead then, we explicitly use the previous version of the python package (3.12.5).