### PR TITLE
Hotfix for Transient problems in parallel

### DIFF
--- a/include/problem_operators/problem_operator_interface.h
+++ b/include/problem_operators/problem_operator_interface.h
@@ -13,7 +13,7 @@ public:
   virtual void SetGridFunctions();
   virtual void Init(mfem::BlockVector & X);
 
-  mfem::Array<int> _true_offsets, _block_true_offsets;
+  mfem::Array<int> _block_true_offsets;
 
   mfem::BlockVector _true_x, _true_rhs;
   mfem::OperatorHandle _equation_system_operator;

--- a/include/problem_operators/problem_operator_interface.h
+++ b/include/problem_operators/problem_operator_interface.h
@@ -11,6 +11,8 @@ public:
   virtual ~ProblemOperatorInterface() = default;
 
   virtual void SetGridFunctions();
+  virtual void SetTestVariablesFromTrueVectors();
+  virtual void SetTrialVariablesFromTrueVectors();
   virtual void Init(mfem::BlockVector & X);
 
   mfem::Array<int> _block_true_offsets;

--- a/src/executioners/MFEMTransient.C
+++ b/src/executioners/MFEMTransient.C
@@ -52,6 +52,9 @@ MFEMTransient::step(double dt, int it) const
   // Advance time step.
   _problem_data._ode_solver->Step(_problem_data._f, _t, dt);
 
+  // Synchonise time dependent GridFunctions with updated DoF data.
+  _problem_operator->SetTestVariablesFromTrueVectors();
+
   // Sync Host/Device
   _problem_data._f.HostRead();
 

--- a/src/problem_operators/problem_operator.C
+++ b/src/problem_operators/problem_operator.C
@@ -7,7 +7,7 @@ void
 ProblemOperator::SetGridFunctions()
 {
   ProblemOperatorInterface::SetGridFunctions();
-  width = height = _true_offsets[_trial_variables.size()];
+  width = height = _block_true_offsets[_trial_variables.size()];
 };
 
 } // namespace platypus

--- a/src/problem_operators/problem_operator_interface.C
+++ b/src/problem_operators/problem_operator_interface.C
@@ -31,4 +31,22 @@ ProblemOperatorInterface::Init(mfem::BlockVector & X)
   }
 }
 
+void
+ProblemOperatorInterface::SetTestVariablesFromTrueVectors()
+{
+  for (unsigned int ind = 0; ind < _test_variables.size(); ++ind)
+  {
+    _test_variables.at(ind)->SetFromTrueVector();
+  }
+}
+
+void
+ProblemOperatorInterface::SetTrialVariablesFromTrueVectors()
+{
+  for (unsigned int ind = 0; ind < _trial_variables.size(); ++ind)
+  {
+    _trial_variables.at(ind)->SetFromTrueVector();
+  }
+}
+
 }

--- a/src/problem_operators/problem_operator_interface.C
+++ b/src/problem_operators/problem_operator_interface.C
@@ -17,14 +17,6 @@ ProblemOperatorInterface::SetGridFunctions()
   }
   _block_true_offsets.PartialSum();
 
-  _true_offsets.SetSize(_trial_variables.size() + 1);
-  _true_offsets[0] = 0;
-  for (unsigned int ind = 0; ind < _trial_variables.size(); ++ind)
-  {
-    _true_offsets[ind + 1] = _trial_variables.at(ind)->ParFESpace()->GetVSize();
-  }
-  _true_offsets.PartialSum();
-
   _true_x.Update(_block_true_offsets);
   _true_rhs.Update(_block_true_offsets);
 }
@@ -32,10 +24,10 @@ ProblemOperatorInterface::SetGridFunctions()
 void
 ProblemOperatorInterface::Init(mfem::BlockVector & X)
 {
-  X.Update(_true_offsets);
+  X.Update(_block_true_offsets);
   for (size_t i = 0; i < _test_variables.size(); ++i)
   {
-    _test_variables.at(i)->MakeRef(_test_variables.at(i)->ParFESpace(), X, _true_offsets[i]);
+    _test_variables.at(i)->MakeTRef(_test_variables.at(i)->ParFESpace(), X, _block_true_offsets[i]);
   }
 }
 

--- a/src/problem_operators/time_domain_equation_system_problem_operator.C
+++ b/src/problem_operators/time_domain_equation_system_problem_operator.C
@@ -27,6 +27,7 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
                                                        mfem::Vector & dX_dt)
 {
   dX_dt = 0.0;
+  SetTestVariablesFromTrueVectors();
   for (unsigned int ind = 0; ind < _trial_variables.size(); ++ind)
   {
     _trial_variables.at(ind)->MakeTRef(
@@ -50,6 +51,7 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
   _problem._nonlinear_solver->SetSolver(*_problem._jacobian_solver);
   _problem._nonlinear_solver->SetOperator(*GetEquationSystem());
   _problem._nonlinear_solver->Mult(_true_rhs, dX_dt);
+  SetTrialVariablesFromTrueVectors();
 }
 
 void

--- a/src/problem_operators/time_domain_equation_system_problem_operator.C
+++ b/src/problem_operators/time_domain_equation_system_problem_operator.C
@@ -29,8 +29,8 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
   dX_dt = 0.0;
   for (unsigned int ind = 0; ind < _trial_variables.size(); ++ind)
   {
-    _trial_variables.at(ind)->MakeRef(
-        _trial_variables.at(ind)->ParFESpace(), dX_dt, _true_offsets[ind]);
+    _trial_variables.at(ind)->MakeTRef(
+        _trial_variables.at(ind)->ParFESpace(), dX_dt, _block_true_offsets[ind]);
   }
   const double time = GetTime();
   for (auto & coef : _problem._scalar_manager)

--- a/src/problem_operators/time_domain_problem_operator.C
+++ b/src/problem_operators/time_domain_problem_operator.C
@@ -17,7 +17,7 @@ void
 TimeDomainProblemOperator::SetGridFunctions()
 {
   ProblemOperatorInterface::SetGridFunctions();
-  width = height = _true_offsets[_trial_variables.size()];
+  width = height = _block_true_offsets[_trial_variables.size()];
 }
 
 } // namespace platypus


### PR DESCRIPTION
This PR fixes a bug seen when running transient problems in parallel where the update vector dX_dt was set to a different size than the residual vector. `_block_true_offsets` is now used consistently throughout ProblemOperators, using `GridFunction::MakeTRef` to set gridfunction data from solution vectors.