### PR TITLE
Fix BlockVector init bug

### DIFF
--- a/src/problem_operators/problem_operator_interface.C
+++ b/src/problem_operators/problem_operator_interface.C
@@ -25,6 +25,7 @@ void
 ProblemOperatorInterface::Init(mfem::BlockVector & X)
 {
   X.Update(_block_true_offsets);
+  X = 0.0;
   for (size_t i = 0; i < _test_variables.size(); ++i)
   {
     _test_variables.at(i)->MakeTRef(_test_variables.at(i)->ParFESpace(), X, _block_true_offsets[i]);


### PR DESCRIPTION
This PR fixes a small bug which can crash runs unpredictably.

In `ProblemOperatorInterface::Init`, the `BlockVector` of a given variable has its size and offsets updated, with the relevant amount of memory allocated for the object. This is done by MFEM's `Vector::SetSize` which calls upon `Memory<T>::New`. The latter function allocates memory without initialising it, meaning any memory remains already existing in that space allocated for it will stay there. The `BlockVector` will then interpret those values as elements of its array. In principle this shouldn't be an issue because before the run begins properly these values will get initialised to their proper values or they will host the result of some calculation step. However, MFEM's `NewtonSolver::Mult` has a check that the `BlockVector` is finite before it gets initialised. Thus, if some memory remains in those spaces and any element gets interpreted by `BlockVector` as an `inf` or `nan`, this will fail MFEM's finiteness check and crash the run. Because the content of newly allocated memory spaces is effectively unpredictable, this crash may happen at any time. All of this can be prevented by simply initialising new `BlockVectors` with finite values. Here we choose zero.