### PR TITLE
Fix incorrect coverage reporting due to skipped tests

### DIFF
--- a/docker/platypus-deps/Dockerfile
+++ b/docker/platypus-deps/Dockerfile
@@ -2,7 +2,7 @@
 # hadolint global ignore=DL3008,DL3013
 
 # Get base image
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # This is needed or it mpiexec complains because docker runs as root
 # Discussion on this issue https://github.com/open-mpi/ompi/issues/4451
@@ -33,7 +33,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
     python3-deepdiff \
     python3-jinja2 \
     python3-livereload \
-    python3-packaging \
     python3-pybtex \
     python3-pylatexenc \
     python3-xmltodict \
@@ -45,6 +44,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
     libhdf5-openmpi-dev \
     libnetcdf-dev \
     libsdl2-dev \
+    libtirpc-dev \
     rsync \
     xxd && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/platypus/Dockerfile
+++ b/docker/platypus/Dockerfile
@@ -27,19 +27,18 @@ RUN make -j$compile_cores coverage=$coverage
 
 # Build Platypus docs
 WORKDIR /$WORKDIR/platypus
-RUN make -j$compile_cores
 RUN doxygen doc/content/doxygen/Doxyfile
 WORKDIR /$WORKDIR/platypus/doc
 RUN ./moosedocs.py build
 
 # Test Platypus regression tests
 WORKDIR /$WORKDIR/platypus 
-RUN make test linkcoverage=$coverage
+RUN make test
 
 # Build Platypus unit tests
 WORKDIR /$WORKDIR/platypus/unit
-RUN make -j$compile_cores coverage=$coverage
+RUN make -j$compile_cores
 
 # Test Platypus unit tests
 WORKDIR /$WORKDIR/platypus/unit
-RUN make test linkcoverage=$coverage
+RUN make test


### PR DESCRIPTION
Closes #72.

Mea culpa!

In 902dc1c, I switched from pip to apt to install the necessary python dependencies.
Turns out the version of deepdiff in the repositories for Ubuntu 22.04 isn't sufficiently new and practically all tests are being skipped as a result. :/ I'm testing moving over to 24.04 whose version of deepdiff is new enough. ~if that's problematic, I'll revert to pip.~

Fixed: https://app.codecov.io/gh/aurora-multiphysics/platypus/commit/70d5260e13c39f4f82e07a2b7156009f131ba139