### PR TITLE
Hotfix for FESpace usage in Transfers

### DIFF
--- a/src/mesh/MFEMMesh.C
+++ b/src/mesh/MFEMMesh.C
@@ -47,10 +47,6 @@ MFEMMesh::buildMesh()
   // Build the MFEM ParMesh from a serial MFEM mesh
   mfem::Mesh mfem_ser_mesh(getFileName());
 
-  mooseAssert(mfem_ser_mesh.Dimension() == 3, "Only 3D meshes are currently supported");
-  mooseAssert(isParamSetByUser("dim") ? getParam<MooseEnum>("dim") == 3 : true,
-              "Only 3D meshes are currently supported");
-
   if (isParamSetByUser("serial_refine") && isParamSetByUser("uniform_refine"))
     paramError(
         "Cannot define serial_refine and uniform_refine to be nonzero at the same time (they "

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_between_subapps/parent.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_between_subapps/parent.i
@@ -11,7 +11,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_between_subapps/sub_recv.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_between_subapps/sub_recv.i
@@ -11,7 +11,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_between_subapps/sub_send.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_between_subapps/sub_send.i
@@ -10,7 +10,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_from_sub/parent.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_from_sub/parent.i
@@ -11,7 +11,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_from_sub/sub.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_from_sub/sub.i
@@ -10,7 +10,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_to_sub/parent.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_to_sub/parent.i
@@ -10,7 +10,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []

--- a/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_to_sub/sub.i
+++ b/test/tests/transfers/multiapp_copy_transfers/mfem_linear_lagrange_to_sub/sub.i
@@ -11,7 +11,7 @@
 
 [FESpaces]
   [H1FESpace]
-    type = MFEMFESpace
+    type = MFEMScalarFESpace
     fec_type = H1
     fec_order = FIRST
   []


### PR DESCRIPTION
The new tests added in #66 are failing following the merge of #78 due to the usage of `MFEMFESpace` in them. Furthermore, the assertions checking for a 3D mesh are no longer needed, and otherwise cause this to fail. 