### PR TITLE
WIP: Support for multivariate nonlinear problems

### DIFF
--- a/doc/content/source/kernels/MFEMKernel.md
+++ b/doc/content/source/kernels/MFEMKernel.md
@@ -18,6 +18,6 @@ forms, the trial variable that the integrator acts on is the variable returned f
 equations (labeled by test variable) with the trial variable solved using them, the set of test
 variable names is the same as the set of trial variable names for a square system.
 
-`MFEMKernel` is a purely virtual base class. Derived classes should override the `createBFIntegrator`
-and/or the `createLFIntegrator` methods to return a `BilinearFormIntegrator` and/or a
+`MFEMKernel` is a purely virtual base class. Derived classes should override the `createJacobianContribution`
+and/or the `createResidualContribution` methods to return a `BilinearFormIntegrator` and/or a
 `LinearFormIntegrator` (respectively) to add to the `EquationSystem`.  

--- a/include/bcs/MFEMConvectiveHeatFluxBC.h
+++ b/include/bcs/MFEMConvectiveHeatFluxBC.h
@@ -13,10 +13,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
+  virtual mfem::LinearFormIntegrator * createResidualContribution();
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution();
 
 protected:
   std::shared_ptr<mfem::FunctionCoefficient> _heat_transfer_coef;

--- a/include/bcs/MFEMIntegratedBC.h
+++ b/include/bcs/MFEMIntegratedBC.h
@@ -11,10 +11,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator() = 0;
+  virtual mfem::LinearFormIntegrator * createResidualContribution() = 0;
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() = 0;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() = 0;
 
   // Get name of the trial variable (gridfunction) the kernel acts on.
   // Defaults to the name of the test variable labelling the weak form.

--- a/include/bcs/MFEMScalarBoundaryIntegratedBC.h
+++ b/include/bcs/MFEMScalarBoundaryIntegratedBC.h
@@ -10,10 +10,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
+  virtual mfem::LinearFormIntegrator * createResidualContribution();
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution();
 
 protected:
   std::string _coef_name;

--- a/include/bcs/MFEMVectorBoundaryIntegratedBC.h
+++ b/include/bcs/MFEMVectorBoundaryIntegratedBC.h
@@ -10,10 +10,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
+  virtual mfem::LinearFormIntegrator * createResidualContribution();
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution();
 
 protected:
   std::vector<Real> _vec_value;

--- a/include/bcs/MFEMVectorFunctionBoundaryIntegratedBC.h
+++ b/include/bcs/MFEMVectorFunctionBoundaryIntegratedBC.h
@@ -10,10 +10,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
+  virtual mfem::LinearFormIntegrator * createResidualContribution();
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution();
 
 protected:
   std::shared_ptr<mfem::VectorCoefficient> _vec_coef{nullptr};

--- a/include/bcs/MFEMVectorFunctionNormalIntegratedBC.h
+++ b/include/bcs/MFEMVectorFunctionNormalIntegratedBC.h
@@ -10,10 +10,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
+  virtual mfem::LinearFormIntegrator * createResidualContribution();
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution();
 
 protected:
   std::shared_ptr<mfem::VectorFunctionCoefficient> _vec_coef;

--- a/include/bcs/MFEMVectorNormalIntegratedBC.h
+++ b/include/bcs/MFEMVectorNormalIntegratedBC.h
@@ -10,10 +10,10 @@ public:
 
   // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
   // caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator();
+  virtual mfem::LinearFormIntegrator * createResidualContribution();
 
   // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator();
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution();
 
 protected:
   std::vector<Real> _vec_value;

--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -106,7 +106,7 @@ protected:
       auto kernels = kernels_map.GetRef(test_var_name).GetRef(trial_var_name);
       for (auto & kernel : kernels)
       {
-        mfem::BilinearFormIntegrator * integ = kernel->createBFIntegrator();
+        mfem::BilinearFormIntegrator * integ = kernel->createJacobianContribution();
         if (integ != nullptr)
         {
           kernel->isSubdomainRestricted()
@@ -128,7 +128,7 @@ protected:
       auto kernels = kernels_map.GetRef(test_var_name).GetRef(test_var_name);
       for (auto & kernel : kernels)
       {
-        mfem::LinearFormIntegrator * integ = kernel->createLFIntegrator();
+        mfem::LinearFormIntegrator * integ = kernel->createResidualContribution();
         if (integ != nullptr)
         {
           kernel->isSubdomainRestricted()
@@ -154,7 +154,7 @@ protected:
       auto bcs = integrated_bc_map.GetRef(test_var_name).GetRef(trial_var_name);
       for (auto & bc : bcs)
       {
-        mfem::BilinearFormIntegrator * integ = bc->createBFIntegrator();
+        mfem::BilinearFormIntegrator * integ = bc->createJacobianContribution();
         if (integ != nullptr)
         {
           bc->isBoundaryRestricted()
@@ -177,7 +177,7 @@ protected:
       auto bcs = integrated_bc_map.GetRef(test_var_name).GetRef(test_var_name);
       for (auto & bc : bcs)
       {
-        mfem::LinearFormIntegrator * integ = bc->createLFIntegrator();
+        mfem::LinearFormIntegrator * integ = bc->createResidualContribution();
         if (integ != nullptr)
         {
           bc->isBoundaryRestricted()

--- a/include/equation_systems/equation_system.h
+++ b/include/equation_systems/equation_system.h
@@ -203,7 +203,7 @@ protected:
   platypus::NamedFieldsMap<std::vector<std::shared_ptr<MFEMEssentialBC>>> _essential_bc_map;
 
   mutable mfem::OperatorHandle _jacobian;
-
+  mutable mfem::Vector _trueRHS;
   mfem::AssemblyLevel _assembly_level;
 };
 

--- a/include/kernels/MFEMCurlCurlKernel.h
+++ b/include/kernels/MFEMCurlCurlKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMCurlCurlKernel(const InputParameters & parameters);
   ~MFEMCurlCurlKernel() override {}
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMDiffusionKernel.h
+++ b/include/kernels/MFEMDiffusionKernel.h
@@ -11,7 +11,7 @@ public:
 
   MFEMDiffusionKernel(const InputParameters & parameters);
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMDivDivKernel.h
+++ b/include/kernels/MFEMDivDivKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMDivDivKernel(const InputParameters & parameters);
   ~MFEMDivDivKernel() override {}
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMKernel.h
+++ b/include/kernels/MFEMKernel.h
@@ -16,8 +16,8 @@ public:
   virtual ~MFEMKernel() = default;
 
   // Create a new MFEM integrator to apply to the weak form. Ownership managed by the caller.
-  virtual mfem::LinearFormIntegrator * createLFIntegrator() { return nullptr; }
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() { return nullptr; }
+  virtual mfem::LinearFormIntegrator * createResidualContribution() { return nullptr; }
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() { return nullptr; }
 
   // Get name of the test variable labelling the weak form this kernel is added to
   const std::string & getTestVariableName() const { return _test_var_name; }

--- a/include/kernels/MFEMLinearElasticityKernel.h
+++ b/include/kernels/MFEMLinearElasticityKernel.h
@@ -16,7 +16,7 @@ public:
 
   MFEMLinearElasticityKernel(const InputParameters & parameters);
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _lambda_name;

--- a/include/kernels/MFEMMassKernel.h
+++ b/include/kernels/MFEMMassKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMMassKernel(const InputParameters & parameters);
   ~MFEMMassKernel() override {}
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMMixedScalarCurlKernel.h
+++ b/include/kernels/MFEMMixedScalarCurlKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMMixedScalarCurlKernel(const InputParameters & parameters);
   ~MFEMMixedScalarCurlKernel() override {}
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMMixedVectorGradientKernel.h
+++ b/include/kernels/MFEMMixedVectorGradientKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMMixedVectorGradientKernel(const InputParameters & parameters);
   ~MFEMMixedVectorGradientKernel() override = default;
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMVectorDomainLFKernel.h
+++ b/include/kernels/MFEMVectorDomainLFKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMVectorDomainLFKernel(const InputParameters & parameters);
   ~MFEMVectorDomainLFKernel() override {}
 
-  virtual mfem::LinearFormIntegrator * createLFIntegrator() override;
+  virtual mfem::LinearFormIntegrator * createResidualContribution() override;
 
 protected:
   std::string _vec_coef_name;

--- a/include/kernels/MFEMVectorFEDomainLFKernel.h
+++ b/include/kernels/MFEMVectorFEDomainLFKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMVectorFEDomainLFKernel(const InputParameters & parameters);
   ~MFEMVectorFEDomainLFKernel() override {}
 
-  virtual mfem::LinearFormIntegrator * createLFIntegrator() override;
+  virtual mfem::LinearFormIntegrator * createResidualContribution() override;
 
 protected:
   std::shared_ptr<mfem::VectorCoefficient> _vec_coef{nullptr};

--- a/include/kernels/MFEMVectorFEMassKernel.h
+++ b/include/kernels/MFEMVectorFEMassKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMVectorFEMassKernel(const InputParameters & parameters);
   ~MFEMVectorFEMassKernel() override {}
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/include/kernels/MFEMVectorFEWeakDivergenceKernel.h
+++ b/include/kernels/MFEMVectorFEWeakDivergenceKernel.h
@@ -12,7 +12,7 @@ public:
   MFEMVectorFEWeakDivergenceKernel(const InputParameters & parameters);
   ~MFEMVectorFEWeakDivergenceKernel() override = default;
 
-  virtual mfem::BilinearFormIntegrator * createBFIntegrator() override;
+  virtual mfem::BilinearFormIntegrator * createJacobianContribution() override;
 
 protected:
   std::string _coef_name;

--- a/src/bcs/MFEMConvectiveHeatFluxBC.C
+++ b/src/bcs/MFEMConvectiveHeatFluxBC.C
@@ -33,14 +33,14 @@ MFEMConvectiveHeatFluxBC::MFEMConvectiveHeatFluxBC(const InputParameters & param
 // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
 // caller.
 mfem::LinearFormIntegrator *
-MFEMConvectiveHeatFluxBC::createLFIntegrator()
+MFEMConvectiveHeatFluxBC::createResidualContribution()
 {
   return new mfem::BoundaryLFIntegrator(*_external_heat_flux_coef);
 }
 
 // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
-MFEMConvectiveHeatFluxBC::createBFIntegrator()
+MFEMConvectiveHeatFluxBC::createJacobianContribution()
 {
   return new mfem::BoundaryMassIntegrator(*_heat_transfer_coef);
 }

--- a/src/bcs/MFEMScalarBoundaryIntegratedBC.C
+++ b/src/bcs/MFEMScalarBoundaryIntegratedBC.C
@@ -24,14 +24,14 @@ MFEMScalarBoundaryIntegratedBC::MFEMScalarBoundaryIntegratedBC(const InputParame
 // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
 // caller.
 mfem::LinearFormIntegrator *
-MFEMScalarBoundaryIntegratedBC::createLFIntegrator()
+MFEMScalarBoundaryIntegratedBC::createResidualContribution()
 {
   return new mfem::BoundaryLFIntegrator(_coef);
 }
 
 // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
-MFEMScalarBoundaryIntegratedBC::createBFIntegrator()
+MFEMScalarBoundaryIntegratedBC::createJacobianContribution()
 {
   return nullptr;
 }

--- a/src/bcs/MFEMVectorBoundaryIntegratedBC.C
+++ b/src/bcs/MFEMVectorBoundaryIntegratedBC.C
@@ -25,14 +25,14 @@ MFEMVectorBoundaryIntegratedBC::MFEMVectorBoundaryIntegratedBC(const InputParame
 // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
 // caller.
 mfem::LinearFormIntegrator *
-MFEMVectorBoundaryIntegratedBC::createLFIntegrator()
+MFEMVectorBoundaryIntegratedBC::createResidualContribution()
 {
   return new mfem::VectorBoundaryLFIntegrator(*_vec_coef);
 }
 
 // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
-MFEMVectorBoundaryIntegratedBC::createBFIntegrator()
+MFEMVectorBoundaryIntegratedBC::createJacobianContribution()
 {
   return nullptr;
 }

--- a/src/bcs/MFEMVectorFunctionBoundaryIntegratedBC.C
+++ b/src/bcs/MFEMVectorFunctionBoundaryIntegratedBC.C
@@ -22,14 +22,14 @@ MFEMVectorFunctionBoundaryIntegratedBC::MFEMVectorFunctionBoundaryIntegratedBC(
 // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
 // caller.
 mfem::LinearFormIntegrator *
-MFEMVectorFunctionBoundaryIntegratedBC::createLFIntegrator()
+MFEMVectorFunctionBoundaryIntegratedBC::createResidualContribution()
 {
   return new mfem::VectorBoundaryLFIntegrator(*_vec_coef);
 }
 
 // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
-MFEMVectorFunctionBoundaryIntegratedBC::createBFIntegrator()
+MFEMVectorFunctionBoundaryIntegratedBC::createJacobianContribution()
 {
   return nullptr;
 }

--- a/src/bcs/MFEMVectorFunctionNormalIntegratedBC.C
+++ b/src/bcs/MFEMVectorFunctionNormalIntegratedBC.C
@@ -22,14 +22,14 @@ MFEMVectorFunctionNormalIntegratedBC::MFEMVectorFunctionNormalIntegratedBC(
 // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
 // caller.
 mfem::LinearFormIntegrator *
-MFEMVectorFunctionNormalIntegratedBC::createLFIntegrator()
+MFEMVectorFunctionNormalIntegratedBC::createResidualContribution()
 {
   return new mfem::BoundaryNormalLFIntegrator(*_vec_coef);
 }
 
 // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
-MFEMVectorFunctionNormalIntegratedBC::createBFIntegrator()
+MFEMVectorFunctionNormalIntegratedBC::createJacobianContribution()
 {
   return nullptr;
 }

--- a/src/bcs/MFEMVectorNormalIntegratedBC.C
+++ b/src/bcs/MFEMVectorNormalIntegratedBC.C
@@ -25,14 +25,14 @@ MFEMVectorNormalIntegratedBC::MFEMVectorNormalIntegratedBC(const InputParameters
 // Create a new MFEM integrator to apply to the RHS of the weak form. Ownership managed by the
 // caller.
 mfem::LinearFormIntegrator *
-MFEMVectorNormalIntegratedBC::createLFIntegrator()
+MFEMVectorNormalIntegratedBC::createResidualContribution()
 {
   return new mfem::BoundaryNormalLFIntegrator(*_vec_coef);
 }
 
 // Create a new MFEM integrator to apply to LHS of the weak form. Ownership managed by the caller.
 mfem::BilinearFormIntegrator *
-MFEMVectorNormalIntegratedBC::createBFIntegrator()
+MFEMVectorNormalIntegratedBC::createJacobianContribution()
 {
   return nullptr;
 }

--- a/src/equation_systems/equation_system.C
+++ b/src/equation_systems/equation_system.C
@@ -162,6 +162,9 @@ EquationSystem::FormSystem(mfem::OperatorHandle & op,
   trueX.SyncFromBlocks();
   trueRHS.SyncFromBlocks();
 
+  _trueRHS.SetSize(width);
+  _trueRHS = trueRHS;
+
   op.Reset(aux_a->Ptr());
 }
 
@@ -223,7 +226,8 @@ EquationSystem::FormLegacySystem(mfem::OperatorHandle & op,
     trueX.GetBlock(0).SyncAliasMemory(trueX);
     trueRHS.GetBlock(0).SyncAliasMemory(trueRHS);
   }
-
+  _trueRHS.SetSize(width);
+  _trueRHS = trueRHS;
   // Create monolithic matrix
   op.Reset(mfem::HypreParMatrixFromBlocks(_h_blocks));
 }
@@ -242,6 +246,7 @@ EquationSystem::Mult(const mfem::Vector & x, mfem::Vector & residual) const
   _jacobian->Mult(x, residual);
   x.HostRead();
   residual.HostRead();
+  residual -= _trueRHS;
 }
 
 mfem::Operator &
@@ -526,6 +531,9 @@ TimeDependentEquationSystem::FormLegacySystem(mfem::OperatorHandle & op,
   truedXdt.SyncFromBlocks();
   trueRHS.SyncFromBlocks();
 
+  _trueRHS.SetSize(width);
+  _trueRHS = trueRHS;
+
   // Create monolithic matrix
   op.Reset(mfem::HypreParMatrixFromBlocks(_h_blocks));
 }
@@ -562,6 +570,9 @@ TimeDependentEquationSystem::FormSystem(mfem::OperatorHandle & op,
   trueRHS.GetBlock(0) = aux_rhs;
   truedXdt.SyncFromBlocks();
   trueRHS.SyncFromBlocks();
+
+  _trueRHS.SetSize(width);
+  _trueRHS = trueRHS;
 
   // Create monolithic matrix
   op.Reset(aux_a->Ptr());

--- a/src/kernels/MFEMCurlCurlKernel.C
+++ b/src/kernels/MFEMCurlCurlKernel.C
@@ -27,7 +27,7 @@ MFEMCurlCurlKernel::MFEMCurlCurlKernel(const InputParameters & parameters)
 }
 
 mfem::BilinearFormIntegrator *
-MFEMCurlCurlKernel::createBFIntegrator()
+MFEMCurlCurlKernel::createJacobianContribution()
 {
   return new mfem::CurlCurlIntegrator(_coef);
 }

--- a/src/kernels/MFEMDiffusionKernel.C
+++ b/src/kernels/MFEMDiffusionKernel.C
@@ -25,7 +25,7 @@ MFEMDiffusionKernel::MFEMDiffusionKernel(const InputParameters & parameters)
 }
 
 mfem::BilinearFormIntegrator *
-MFEMDiffusionKernel::createBFIntegrator()
+MFEMDiffusionKernel::createJacobianContribution()
 {
   return new mfem::DiffusionIntegrator(_coef);
 }

--- a/src/kernels/MFEMDivDivKernel.C
+++ b/src/kernels/MFEMDivDivKernel.C
@@ -28,7 +28,7 @@ MFEMDivDivKernel::MFEMDivDivKernel(const InputParameters & parameters)
 }
 
 mfem::BilinearFormIntegrator *
-MFEMDivDivKernel::createBFIntegrator()
+MFEMDivDivKernel::createJacobianContribution()
 {
   return new mfem::DivDivIntegrator(_coef);
 }

--- a/src/kernels/MFEMLinearElasticityKernel.C
+++ b/src/kernels/MFEMLinearElasticityKernel.C
@@ -34,7 +34,7 @@ MFEMLinearElasticityKernel::MFEMLinearElasticityKernel(const InputParameters & p
 }
 
 mfem::BilinearFormIntegrator *
-MFEMLinearElasticityKernel::createBFIntegrator()
+MFEMLinearElasticityKernel::createJacobianContribution()
 {
   return new mfem::ElasticityIntegrator(_lambda, _mu);
 }

--- a/src/kernels/MFEMMassKernel.C
+++ b/src/kernels/MFEMMassKernel.C
@@ -22,7 +22,7 @@ MFEMMassKernel::MFEMMassKernel(const InputParameters & parameters)
 }
 
 mfem::BilinearFormIntegrator *
-MFEMMassKernel::createBFIntegrator()
+MFEMMassKernel::createJacobianContribution()
 {
   return new mfem::MassIntegrator(_coef);
 }

--- a/src/kernels/MFEMMixedScalarCurlKernel.C
+++ b/src/kernels/MFEMMixedScalarCurlKernel.C
@@ -24,7 +24,7 @@ MFEMMixedScalarCurlKernel::MFEMMixedScalarCurlKernel(const InputParameters & par
 }
 
 mfem::BilinearFormIntegrator *
-MFEMMixedScalarCurlKernel::createBFIntegrator()
+MFEMMixedScalarCurlKernel::createJacobianContribution()
 {
   return new mfem::MixedScalarCurlIntegrator(_coef);
 }

--- a/src/kernels/MFEMMixedVectorGradientKernel.C
+++ b/src/kernels/MFEMMixedVectorGradientKernel.C
@@ -25,7 +25,7 @@ MFEMMixedVectorGradientKernel::MFEMMixedVectorGradientKernel(const InputParamete
 }
 
 mfem::BilinearFormIntegrator *
-MFEMMixedVectorGradientKernel::createBFIntegrator()
+MFEMMixedVectorGradientKernel::createJacobianContribution()
 {
   return new mfem::MixedVectorGradientIntegrator(_coef);
 }

--- a/src/kernels/MFEMVectorDomainLFKernel.C
+++ b/src/kernels/MFEMVectorDomainLFKernel.C
@@ -21,7 +21,7 @@ MFEMVectorDomainLFKernel::MFEMVectorDomainLFKernel(const InputParameters & param
 }
 
 mfem::LinearFormIntegrator *
-MFEMVectorDomainLFKernel::createLFIntegrator()
+MFEMVectorDomainLFKernel::createResidualContribution()
 {
   return new mfem::VectorDomainLFIntegrator(_vec_coef);
 }

--- a/src/kernels/MFEMVectorFEDomainLFKernel.C
+++ b/src/kernels/MFEMVectorFEDomainLFKernel.C
@@ -21,7 +21,7 @@ MFEMVectorFEDomainLFKernel::MFEMVectorFEDomainLFKernel(const InputParameters & p
 }
 
 mfem::LinearFormIntegrator *
-MFEMVectorFEDomainLFKernel::createLFIntegrator()
+MFEMVectorFEDomainLFKernel::createResidualContribution()
 {
   return new mfem::VectorFEDomainLFIntegrator(*_vec_coef);
 }

--- a/src/kernels/MFEMVectorFEMassKernel.C
+++ b/src/kernels/MFEMVectorFEMassKernel.C
@@ -24,7 +24,7 @@ MFEMVectorFEMassKernel::MFEMVectorFEMassKernel(const InputParameters & parameter
 }
 
 mfem::BilinearFormIntegrator *
-MFEMVectorFEMassKernel::createBFIntegrator()
+MFEMVectorFEMassKernel::createJacobianContribution()
 {
   return new mfem::VectorFEMassIntegrator(_coef);
 }

--- a/src/kernels/MFEMVectorFEWeakDivergenceKernel.C
+++ b/src/kernels/MFEMVectorFEWeakDivergenceKernel.C
@@ -24,7 +24,7 @@ MFEMVectorFEWeakDivergenceKernel::MFEMVectorFEWeakDivergenceKernel(
 }
 
 mfem::BilinearFormIntegrator *
-MFEMVectorFEWeakDivergenceKernel::createBFIntegrator()
+MFEMVectorFEWeakDivergenceKernel::createJacobianContribution()
 {
   return new mfem::VectorFEWeakDivergenceIntegrator(_coef);
 }

--- a/src/problem_operators/equation_system_problem_operator.C
+++ b/src/problem_operators/equation_system_problem_operator.C
@@ -21,10 +21,11 @@ void
 EquationSystemProblemOperator::Solve(mfem::Vector & X)
 {
   GetEquationSystem()->BuildJacobian(_true_x, _true_rhs);
-
+  mfem::Vector zero_vec(_true_rhs.Size());
+  zero_vec = 0.0;
   _problem._nonlinear_solver->SetSolver(*_problem._jacobian_solver);
   _problem._nonlinear_solver->SetOperator(*GetEquationSystem());
-  _problem._nonlinear_solver->Mult(_true_rhs, _true_x);
+  _problem._nonlinear_solver->Mult(zero_vec, _true_x);
 
   GetEquationSystem()->RecoverFEMSolution(_true_x, _problem._gridfunctions);
 }

--- a/src/problem_operators/time_domain_equation_system_problem_operator.C
+++ b/src/problem_operators/time_domain_equation_system_problem_operator.C
@@ -48,9 +48,11 @@ TimeDomainEquationSystemProblemOperator::ImplicitSolve(const double dt,
   }
   BuildEquationSystemOperator(dt);
 
+  mfem::Vector zero_vec(_true_rhs.Size());
+  zero_vec = 0.0;
   _problem._nonlinear_solver->SetSolver(*_problem._jacobian_solver);
   _problem._nonlinear_solver->SetOperator(*GetEquationSystem());
-  _problem._nonlinear_solver->Mult(_true_rhs, dX_dt);
+  _problem._nonlinear_solver->Mult(zero_vec, dX_dt);
   SetTrialVariablesFromTrueVectors();
 }
 

--- a/unit/src/MFEMIntegratedBCTest.C
+++ b/unit/src/MFEMIntegratedBCTest.C
@@ -27,11 +27,11 @@ TEST_F(MFEMIntegratedBCTest, MFEMVectorNormalIntegratedBC)
 
   // Test MFEMVectorNormalIntegratedBC returns an integrator of the expected type
   auto lf_integrator =
-      dynamic_cast<mfem::BoundaryNormalLFIntegrator *>(integrated_bc.createLFIntegrator());
+      dynamic_cast<mfem::BoundaryNormalLFIntegrator *>(integrated_bc.createResidualContribution());
   ASSERT_NE(lf_integrator, nullptr);
   delete lf_integrator;
 
-  auto blf_integrator = integrated_bc.createBFIntegrator();
+  auto blf_integrator = integrated_bc.createJacobianContribution();
   ASSERT_EQ(blf_integrator, nullptr);
   delete blf_integrator;
 }
@@ -57,11 +57,11 @@ TEST_F(MFEMIntegratedBCTest, MFEMVectorFunctionNormalIntegratedBC)
 
   // Test MFEMVectorNormalIntegratedBC returns an integrator of the expected type
   auto lf_integrator =
-      dynamic_cast<mfem::BoundaryNormalLFIntegrator *>(integrated_bc.createLFIntegrator());
+      dynamic_cast<mfem::BoundaryNormalLFIntegrator *>(integrated_bc.createResidualContribution());
   ASSERT_NE(lf_integrator, nullptr);
   delete lf_integrator;
 
-  auto blf_integrator = integrated_bc.createBFIntegrator();
+  auto blf_integrator = integrated_bc.createJacobianContribution();
   ASSERT_EQ(blf_integrator, nullptr);
   delete blf_integrator;
 }
@@ -87,11 +87,11 @@ TEST_F(MFEMIntegratedBCTest, MFEMScalarBoundaryIntegratedBC)
 
   // Test MFEMScalarBoundaryIntegratedBC returns an integrator of the expected type
   auto lf_integrator =
-      dynamic_cast<mfem::BoundaryLFIntegrator *>(integrated_bc.createLFIntegrator());
+      dynamic_cast<mfem::BoundaryLFIntegrator *>(integrated_bc.createResidualContribution());
   ASSERT_NE(lf_integrator, nullptr);
   delete lf_integrator;
 
-  auto blf_integrator = integrated_bc.createBFIntegrator();
+  auto blf_integrator = integrated_bc.createJacobianContribution();
   ASSERT_EQ(blf_integrator, nullptr);
   delete blf_integrator;
 }
@@ -121,12 +121,12 @@ TEST_F(MFEMIntegratedBCTest, MFEMConvectiveHeatFluxBC)
 
   // Test MFEMConvectiveHeatFluxBC returns an integrator of the expected type
   auto lf_integrator =
-      dynamic_cast<mfem::BoundaryLFIntegrator *>(integrated_bc.createLFIntegrator());
+      dynamic_cast<mfem::BoundaryLFIntegrator *>(integrated_bc.createResidualContribution());
   ASSERT_NE(lf_integrator, nullptr);
   delete lf_integrator;
 
   auto blf_integrator =
-      dynamic_cast<mfem::BoundaryMassIntegrator *>(integrated_bc.createBFIntegrator());
+      dynamic_cast<mfem::BoundaryMassIntegrator *>(integrated_bc.createJacobianContribution());
   ASSERT_NE(blf_integrator, nullptr);
   delete blf_integrator;
 }
@@ -142,11 +142,12 @@ TEST_F(MFEMIntegratedBCTest, MFEMVectorBoundaryIntegratedBC)
       addObject<MFEMVectorBoundaryIntegratedBC>("MFEMVectorBoundaryIntegratedBC", "bc1", bc_params);
 
   // Test MFEMVectorBoundaryIntegratedBC returns an integrator of the expected type
-  auto lf_integrator = dynamic_cast<mfem::VectorBoundaryLFIntegrator *>(bc.createLFIntegrator());
+  auto lf_integrator =
+      dynamic_cast<mfem::VectorBoundaryLFIntegrator *>(bc.createResidualContribution());
   ASSERT_NE(lf_integrator, nullptr);
   delete lf_integrator;
 
-  auto blf_integrator = bc.createBFIntegrator();
+  auto blf_integrator = bc.createJacobianContribution();
   ASSERT_EQ(blf_integrator, nullptr);
   delete blf_integrator;
 }
@@ -169,11 +170,12 @@ TEST_F(MFEMIntegratedBCTest, MFEMVectorFunctionBoundaryIntegratedBC)
       "MFEMVectorFunctionBoundaryIntegratedBC", "bc1", bc_params);
 
   // Test MFEMVectorBoundaryIntegratedBC returns an integrator of the expected type
-  auto lf_integrator = dynamic_cast<mfem::VectorBoundaryLFIntegrator *>(bc.createLFIntegrator());
+  auto lf_integrator =
+      dynamic_cast<mfem::VectorBoundaryLFIntegrator *>(bc.createResidualContribution());
   ASSERT_NE(lf_integrator, nullptr);
   delete lf_integrator;
 
-  auto blf_integrator = bc.createBFIntegrator();
+  auto blf_integrator = bc.createJacobianContribution();
   ASSERT_EQ(blf_integrator, nullptr);
   delete blf_integrator;
 }

--- a/unit/src/MFEMKernelTest.C
+++ b/unit/src/MFEMKernelTest.C
@@ -35,7 +35,7 @@ TEST_F(MFEMKernelTest, MFEMCurlCurlKernel)
       addObject<MFEMCurlCurlKernel>("MFEMCurlCurlKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::CurlCurlIntegrator *>(kernel.createBFIntegrator());
+  auto integrator = dynamic_cast<mfem::CurlCurlIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -59,7 +59,7 @@ TEST_F(MFEMKernelTest, MFEMDiffusionKernel)
       addObject<MFEMDiffusionKernel>("MFEMDiffusionKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::DiffusionIntegrator *>(kernel.createBFIntegrator());
+  auto integrator = dynamic_cast<mfem::DiffusionIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -82,7 +82,7 @@ TEST_F(MFEMKernelTest, MFEMDivDivKernel)
   auto & kernel = addObject<MFEMDivDivKernel>("MFEMDivDivKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::DivDivIntegrator *>(kernel.createBFIntegrator());
+  auto integrator = dynamic_cast<mfem::DivDivIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -107,7 +107,7 @@ TEST_F(MFEMKernelTest, MFEMLinearElasticityKernel)
       addObject<MFEMLinearElasticityKernel>("MFEMLinearElasticityKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::ElasticityIntegrator *>(kernel.createBFIntegrator());
+  auto integrator = dynamic_cast<mfem::ElasticityIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -132,7 +132,7 @@ TEST_F(MFEMKernelTest, MFEMMixedVectorGradientKernel)
 
   // Test MFEMKernel returns an integrator of the expected type
   auto integrator =
-      dynamic_cast<mfem::MixedVectorGradientIntegrator *>(kernel.createBFIntegrator());
+      dynamic_cast<mfem::MixedVectorGradientIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -156,7 +156,8 @@ TEST_F(MFEMKernelTest, MFEMVectorDomainLFKernel)
       addObject<MFEMVectorDomainLFKernel>("MFEMVectorDomainLFKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::VectorDomainLFIntegrator *>(kernel.createLFIntegrator());
+  auto integrator =
+      dynamic_cast<mfem::VectorDomainLFIntegrator *>(kernel.createResidualContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -182,7 +183,8 @@ TEST_F(MFEMKernelTest, MFEMVectorFEDomainLFKernel)
       addObject<MFEMVectorFEDomainLFKernel>("MFEMVectorFEDomainLFKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::VectorFEDomainLFIntegrator *>(kernel.createLFIntegrator());
+  auto integrator =
+      dynamic_cast<mfem::VectorFEDomainLFIntegrator *>(kernel.createResidualContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -206,7 +208,8 @@ TEST_F(MFEMKernelTest, MFEMVectorFEMassKernel)
       addObject<MFEMVectorFEMassKernel>("MFEMVectorFEMassKernel", "kernel1", kernel_params);
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::VectorFEMassIntegrator *>(kernel.createBFIntegrator());
+  auto integrator =
+      dynamic_cast<mfem::VectorFEMassIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -232,7 +235,7 @@ TEST_F(MFEMKernelTest, MFEMVectorFEWeakDivergenceKernel)
 
   // Test MFEMKernel returns an integrator of the expected type
   auto integrator =
-      dynamic_cast<mfem::VectorFEWeakDivergenceIntegrator *>(kernel.createBFIntegrator());
+      dynamic_cast<mfem::VectorFEWeakDivergenceIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }
@@ -262,7 +265,8 @@ TEST_F(MFEMKernelTest, MFEMMixedScalarCurlKernel)
   EXPECT_EQ(trial_name, "trial_variable_name");
 
   // Test MFEMKernel returns an integrator of the expected type
-  auto integrator = dynamic_cast<mfem::MixedScalarCurlIntegrator *>(kernel.createBFIntegrator());
+  auto integrator =
+      dynamic_cast<mfem::MixedScalarCurlIntegrator *>(kernel.createJacobianContribution());
   ASSERT_NE(integrator, nullptr);
   delete integrator;
 }


### PR DESCRIPTION
WIP adding initial support for nonlinear problems via use of a linearised Jacobian, interpreting the existing kernel integrators as Jacobian contributions and moving the subtraction of the RHS from the `NewtonSolver` call to `EquationSystem::Mult`.

Rather than relying on `mfem::NonlinearForm` or `mfem::BlockNonlinearForm` (and their respective integrators), the (linearised) Jacobian contributions are constructed using the existing `mfem::BilinearFormIntegrator`s and residual contributions from `mfem::LinearFormIntegrator`s.

Inspired by a conversation with @SohailSTFC 