### PR TITLE
platypus-deps fix

### DIFF
--- a/docker/platypus-deps/Dockerfile
+++ b/docker/platypus-deps/Dockerfile
@@ -150,7 +150,7 @@ RUN cmake -G Ninja -DMFEM_DIR=/$WORKDIR/mfem/build .. && \
 WORKDIR /$WORKDIR
 RUN git clone https://github.com/idaholab/moose
 WORKDIR /$WORKDIR/moose
-RUN git checkout master && \
+RUN git checkout 6924a39be39d5bfd9093b72179e37e5b7d21f46f && \
     export MOOSE_JOBS=$compile_cores && \
     export PETSC_DIR=/$WORKDIR/petsc && \
     export CC=mpicc && \


### PR DESCRIPTION
This PR specifies a MOOSE commit to use for `platypus-deps`, since after that a bug was introduced, preventing Platypus from being built correctly on the most up-to-date master branch.