### PR TITLE
non linear form unit test

### DIFF
--- a/unit/src/TestNLFormIntegrator.C
+++ b/unit/src/TestNLFormIntegrator.C
@@ -1,16 +1,10 @@
 #include "gtest/gtest.h"
 #include "mfem.hpp"
 
-double
-ff(double u)
-{
-  return u;
-}
-double
-dff(double u)
-{
-  return 1.0;
-}
+static const double alpha = -0.5;
+
+double  ff(const double & u){ return exp(alpha*u); }
+double dff(const double & u){ return alpha*exp(alpha*u); }
 
 // Define a coefficient that, given a grid function u, function func, returns func(u)
 class NonlinearGridFunctionCoefficient : public mfem::Coefficient

--- a/unit/src/TestNLFormIntegrator.C
+++ b/unit/src/TestNLFormIntegrator.C
@@ -260,7 +260,7 @@ TEST(CheckData, TestNonLinearDiffusionIntegratorInhomogenous)
   newton.SetMaxIter(20);
 
   // 10. Solve the nonlinear system.
-  X.SetSubVector(ess_tdof_list, 0.0);
+  X.SetSubVector(ess_tdof_list, 5.0);
   newton.Mult(B, X);
   u1.Distribute(X);
 
@@ -274,6 +274,7 @@ TEST(CheckData, TestNonLinearDiffusionIntegratorInhomogenous)
 
   // 10. Solve the nonlinear system.
   C = 0.0;
+  Y.SetSubVector(ess_tdof_list, 5.0);
   newton.Mult(C, Y);
   u2.Distribute(Y);
   }

--- a/unit/src/TestNLFormIntegrator.C
+++ b/unit/src/TestNLFormIntegrator.C
@@ -1,0 +1,288 @@
+#include "gtest/gtest.h"
+#include "mfem.hpp"
+
+double
+ff(double u)
+{
+  return u;
+}
+double
+dff(double u)
+{
+  return 1.0;
+}
+
+// Define a coefficient that, given a grid function u, function func, returns func(u)
+class NonlinearGridFunctionCoefficient : public mfem::Coefficient
+{
+  mfem::GridFunction & gf;
+  std::function<double(double)> func;
+
+public:
+  NonlinearGridFunctionCoefficient(mfem::GridFunction & gf_, std::function<double(double)> func_)
+    : gf(gf_), func(func_)
+  {
+  }
+  double Eval(mfem::ElementTransformation & T, const mfem::IntegrationPoint & ip)
+  {
+    return func(gf.GetValue(T, ip));
+  }
+};
+
+// Define a nonlinear integrator that computes (f(u), v) and its linearized
+// operator, (u df(u), v).
+//
+// Note that the action (f(u), v) can be computed using DomainLFIntegrator
+// and the Jacobian matrix linearized operator can be computed using
+// MassIntegrator with the appropriate coefficients.
+// This integrator is supported for H1 and L2 fespaces
+class NonlinearMassIntegrator : public mfem::NonlinearFormIntegrator
+{
+  mfem::FiniteElementSpace & fes;
+  mfem::GridFunction gf;
+  mfem::Array<int> dofs;
+  std::function<double(double)> func;
+  std::function<double(double)> dfunc;
+
+public:
+  NonlinearMassIntegrator(mfem::FiniteElementSpace & fes_,
+                          std::function<double(double)> func_,
+                          std::function<double(double)> dfunc_)
+    : fes(fes_), gf(&fes), func(func_), dfunc(dfunc_)
+  {
+  }
+
+  virtual void AssembleElementVector(const mfem::FiniteElement & el,
+                                     mfem::ElementTransformation & Tr,
+                                     const mfem::Vector & elfun,
+                                     mfem::Vector & elvect)
+  {
+    fes.GetElementDofs(Tr.ElementNo, dofs);
+    gf.SetSubVector(dofs, elfun);
+    NonlinearGridFunctionCoefficient coeff(gf, func);
+    mfem::DomainLFIntegrator integ(coeff);
+    integ.AssembleRHSElementVect(el, Tr, elvect);
+  }
+
+  virtual void AssembleElementGrad(const mfem::FiniteElement & el,
+                                   mfem::ElementTransformation & Tr,
+                                   const mfem::Vector & elfun,
+                                   mfem::DenseMatrix & elmat)
+  {
+    fes.GetElementDofs(Tr.ElementNo, dofs);
+    gf.SetSubVector(dofs, elfun);
+    NonlinearGridFunctionCoefficient coeff(gf, dfunc);
+    mfem::MassIntegrator integ(coeff);
+    integ.AssembleElementMatrix(el, Tr, elmat);
+  }
+};
+
+class NLOperator : public mfem::Operator
+{
+private:
+  // The FE-spaces and operators
+  mfem::ParFiniteElementSpace * feSpace = NULL; // FE-Spaces
+  mfem::Operator * NLForm = NULL;               // Operators used for E(U)
+
+public:
+  // Creates my block non-linear form
+  NLOperator(mfem::ParFiniteElementSpace * feSpace_, mfem::ParNonlinearForm * NLForm_);
+
+  // Destroys my block linear form
+  ~NLOperator();
+
+  // The residual operator
+  virtual void Mult(const mfem::Vector & x, mfem::Vector & y) const override;
+
+  // The Jacobian operator (Can be used for preconditioning)
+  mfem::Operator & GetGradient(const mfem::Vector & x) const override;
+
+  // A null and void function that inherits from
+  // the Operator class
+  virtual void SetOperator(const mfem::Operator & op) {};
+};
+
+NLOperator::NLOperator(mfem::ParFiniteElementSpace * feSpace_, mfem::ParNonlinearForm * NLForm_)
+  : Operator(feSpace_->TrueVSize()), NLForm(NLForm_)
+{
+}
+
+NLOperator::~NLOperator() {};
+
+void
+NLOperator::Mult(const mfem::Vector & x, mfem::Vector & y) const
+{
+  NLForm->Mult(x, y);
+};
+
+mfem::Operator &
+NLOperator::GetGradient(const mfem::Vector & x) const
+{
+  return (NLForm->GetGradient(x));
+};
+
+
+class NLForm: public mfem::Operator{
+  private:
+  mfem::ParFiniteElementSpace &fes;
+    mutable mfem::ParGridFunction x_gf, b_gf;
+
+    //Forms the coefficients
+    mfem::GradientGridFunctionCoefficient gradCf;
+    NonlinearGridFunctionCoefficient  cf, dcf;
+
+    mfem::Array<int> dofs;
+
+    mutable mfem::ParLinearForm   *Residual=NULL; 
+    mutable mfem::ParBilinearForm *Jacobian=NULL;
+    mutable mfem::OperatorHandle GradR;
+    mfem::Solver *Precon;
+  public:
+    NLForm(mfem::ParFiniteElementSpace & fes, mfem::Array<int> BDR_tags);
+
+    // Required to use the native newton solver
+    virtual void Mult(const mfem::Vector &k, mfem::Vector &y) const override;   //Residual Vector
+    virtual mfem::Operator &GetGradient(const mfem::Vector &xp) const override; //Jacobian Matrix
+};
+
+
+NLForm::NLForm(mfem::ParFiniteElementSpace & fes_, mfem::Array<int> BDR_tags): Operator(fes_.TrueVSize()),
+ 						     fes(fes_), x_gf(&fes), b_gf(&fes)
+ 						   , gradCf(&x_gf), cf(x_gf,ff), dcf(x_gf,dff)
+ {
+   //Get the constrained boundary dofs
+   fes.GetEssentialTrueDofs(BDR_tags, dofs);
+ 
+   //Forms the residual vector
+   Residual = new mfem::ParLinearForm(&fes);
+   Residual->AddDomainIntegrator(new mfem::DomainLFIntegrator(cf));
+   Residual->AddDomainIntegrator(new mfem::DomainLFGradIntegrator(gradCf));
+   Residual->UseFastAssembly(true);
+    
+   //Forms the Jacobian matrix which is the
+   //gradient of the residual
+   Jacobian = new mfem::ParBilinearForm(&fes);
+   Jacobian->AddDomainIntegrator(new mfem::MassIntegrator(dcf) );
+   Jacobian->AddDomainIntegrator(new mfem::DiffusionIntegrator );
+ }; 
+
+
+ void NLForm::Mult(const mfem::Vector & x, mfem::Vector & r) const{
+  //Update the residual vector
+  x_gf.Distribute(&x);
+  Residual->Assemble();
+  Residual->ParallelAssemble(b_gf);
+  r = b_gf;
+
+  //Apply the Dirch BCs elimination
+  r.SetSubVector(dofs, 0.00);
+
+  //Update the Jacobian for linear-solve
+  Jacobian->Update();
+  Jacobian->Assemble();
+  Jacobian->FormSystemMatrix(dofs, GradR);
+};
+
+
+mfem::Operator &NLForm::GetGradient(const mfem::Vector &xp) const{
+ return *GradR;
+};
+
+
+TEST(CheckData, TestNonLinearDiffusionIntegratorInhomogenous)
+{
+
+  // 1. Parse command line options
+
+  int order = 1;
+  bool nonzero_rhs = false;
+
+  // 2. Read the mesh from the given mesh file, and refine once uniformly.
+  mfem::Mesh mesh =
+      mfem::Mesh::MakeCartesian2D(4, 4, mfem::Element::Type::QUADRILATERAL, true, 2.0, 2.0);
+  mesh.UniformRefinement();
+  mfem::ParMesh pmesh(MPI_COMM_WORLD, mesh);
+
+  // 3. Define a finite element space on the mesh. Here we use H1 continuous
+  //    high-order Lagrange finite elements of the given order.
+  mfem::H1_FECollection fec(order, mesh.Dimension());
+  mfem::ParFiniteElementSpace fespace(&pmesh, &fec);
+
+  // 4. Extract the list of all the boundaries. These will be marked as
+  //    Dirichlet in order to enforce zero boundary conditions.
+  mfem::Array<int> ess_bdr(pmesh.bdr_attributes.Max());
+  ess_bdr = 1;
+  mfem::Array<int> ess_tdof_list;
+  fespace.GetEssentialTrueDofs(ess_bdr, ess_tdof_list);
+
+  // 5. Define the solution x as a finite element grid function in fespace. Set
+  //    the initial guess to zero, which also sets the boundary conditions.
+  mfem::ParGridFunction u1(&fespace), u2(&fespace);
+  u1 = 0.0;
+  u2 = 0.0;
+
+  // Solve as a non-linear problem.
+
+  // 6. Set up the nonlinear form n(u,v) = (grad u, grad v) + (f(u), v)
+  mfem::ParNonlinearForm n(&fespace);
+  n.AddDomainIntegrator(new NonlinearMassIntegrator(fespace, ff, dff));
+  n.AddDomainIntegrator(new mfem::DiffusionIntegrator);
+
+  // 7. Set up the the right-hand side. For simplicitly, we just use a zero
+  //    vector. Because of the form of the nonlinear function f, it is still
+  //    nontrivial to solve n(u,v) = 0.
+  mfem::ParLinearForm b(&fespace);
+  b = 0.0;
+  if (nonzero_rhs)
+  {
+    mfem::ConstantCoefficient five(5.0);
+    b.AddDomainIntegrator(new mfem::DomainLFIntegrator(five));
+    b.Assemble();
+  }
+
+  // 8. Get true dof vectors and set essential BCs on rhs.
+  mfem::Vector X(fespace.GetTrueVSize()), B(fespace.GetTrueVSize());
+  B = 0.0;
+  u1.GetTrueDofs(X);
+  b.ParallelAssemble(B);
+  n.SetEssentialBC(ess_bdr, &B);
+
+  NLOperator myOp(&fespace, &n);
+
+  // 9. Set up the Newton solver. Each Newton iteration requires a linear
+  //    solve. Here we use UMFPack as a direct solver for these systems.
+  mfem::CGSolver solver(MPI_COMM_WORLD);
+  mfem::NewtonSolver newton(MPI_COMM_WORLD);
+  newton.SetOperator(myOp);
+  newton.SetSolver(solver);
+  newton.SetPrintLevel(1);
+  newton.SetRelTol(1e-10);
+  newton.SetMaxIter(20);
+
+  // 10. Solve the nonlinear system.
+  X.SetSubVector(ess_tdof_list, 5.0);
+  newton.Mult(B, X);
+  u1.Distribute(X);
+
+  // Solve as a linear problem.
+  {
+    mfem::BilinearForm a(&fespace);
+    a.AddDomainIntegrator(new mfem::DiffusionIntegrator);
+    a.AddDomainIntegrator(new mfem::MassIntegrator);
+    a.Assemble();
+
+    mfem::ConstantCoefficient dbcCoef(5.0);
+
+    mfem::OperatorPtr A;
+    mfem::Vector C, Y;
+    u2.ProjectBdrCoefficient(dbcCoef, ess_bdr);
+    a.FormLinearSystem(ess_tdof_list, u2, b, A, Y, C);
+    mfem::GSSmoother M((mfem::SparseMatrix &)(*A));
+    mfem::PCG(*A, M, C, Y, 1, 500, 1e-12, 0.0);
+    a.RecoverFEMSolution(Y, b, u2);
+  }
+
+  u1 -= u2;
+
+  EXPECT_NEAR(u1.Norml2(), 0, 1e-5);
+}

--- a/unit/src/TestNLFormIntegrator.C
+++ b/unit/src/TestNLFormIntegrator.C
@@ -130,6 +130,7 @@ class NLForm: public mfem::Operator{
     //Forms the coefficients
     mfem::GradientGridFunctionCoefficient gradCf;
     NonlinearGridFunctionCoefficient  cf, dcf;
+    mfem::ConstantCoefficient minusfive;
 
     mfem::Array<int> dofs;
 
@@ -148,13 +149,14 @@ class NLForm: public mfem::Operator{
 
 NLForm::NLForm(mfem::ParFiniteElementSpace & fes_, mfem::Array<int> BDR_tags): Operator(fes_.TrueVSize()),
  						     fes(fes_), x_gf(&fes), b_gf(&fes)
- 						   , gradCf(&x_gf), cf(x_gf,ff), dcf(x_gf,dff)
+ 						   , gradCf(&x_gf), cf(x_gf,ff), dcf(x_gf,dff), minusfive(-5.0)
  {
    //Get the constrained boundary dofs
    fes.GetEssentialTrueDofs(BDR_tags, dofs);
  
    //Forms the residual vector
    Residual = new mfem::ParLinearForm(&fes);
+   Residual->AddDomainIntegrator(new mfem::DomainLFIntegrator(minusfive));
    Residual->AddDomainIntegrator(new mfem::DomainLFIntegrator(cf));
    Residual->AddDomainIntegrator(new mfem::DomainLFGradIntegrator(gradCf));
    Residual->UseFastAssembly(true);
@@ -195,7 +197,7 @@ TEST(CheckData, TestNonLinearDiffusionIntegratorInhomogenous)
   // 1. Parse command line options
 
   int order = 1;
-  bool nonzero_rhs = false;
+  bool nonzero_rhs = true;
 
   // 2. Read the mesh from the given mesh file, and refine once uniformly.
   mfem::Mesh mesh =


### PR DESCRIPTION
A unit test was created, for a non-linear problem, to compare the new non-linear form based on MFEM's Bilinear (Jacobin) and Linear(Residual) forms instead of the native MFEM non-linear form due to ease of customizability and variety of existing integrators.

Sohail & Karthik.