### PR TITLE
Pin MFEM Version

### DIFF
--- a/docker/platypus-deps/Dockerfile
+++ b/docker/platypus-deps/Dockerfile
@@ -110,7 +110,7 @@ RUN make install prefix=/$WORKDIR/libCEED/build
 WORKDIR /$WORKDIR
 RUN git clone https://github.com/mfem/mfem.git
 WORKDIR /$WORKDIR/mfem 
-RUN git checkout master && mkdir build
+RUN git checkout 9f2d103b4bb87b76e1ed6b018652a680640fd639 && mkdir build
 WORKDIR /$WORKDIR/mfem/build
 RUN cmake .. \
     -DCMAKE_INSTALL_PREFIX=/$WORKDIR/mfem/installed \


### PR DESCRIPTION
Pins the MFEM version built in the platypus-deps Docker container for our CI to the last commit before the merge of [#4797](https://github.com/mfem/mfem/pull/4797), which changed the reported VTK version number in VTK file outputs.

For use of later MFEM commits, we will need to regenerate any `ParaViewDataCollection` outputs used as gold files. 