### PR TITLE
Ignore VTK version when verifying test results

### DIFF
--- a/docker/platypus-deps/Dockerfile
+++ b/docker/platypus-deps/Dockerfile
@@ -110,7 +110,7 @@ RUN make install prefix=/$WORKDIR/libCEED/build
 WORKDIR /$WORKDIR
 RUN git clone https://github.com/mfem/mfem.git
 WORKDIR /$WORKDIR/mfem 
-RUN git checkout 9f2d103b4bb87b76e1ed6b018652a680640fd639 && mkdir build
+RUN git checkout master && mkdir build
 WORKDIR /$WORKDIR/mfem/build
 RUN cmake .. \
     -DCMAKE_INSTALL_PREFIX=/$WORKDIR/mfem/installed \

--- a/test/tests/kernels/tests
+++ b/test/tests/kernels/tests
@@ -5,6 +5,7 @@
     input = curlcurl.i
     xmldiff = 'OutputData/CurlCurl/Run0/Run0.pvd
                 OutputData/CurlCurl/Run0/Cycle000001/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a definite Maxwell problem with Nedelec elements of the first kind and produce results consistent with MFEM Example 3'
   []
   [./MFEMDiffusion]
@@ -12,6 +13,7 @@
     input = diffusion.i
     xmldiff = 'OutputData/Diffusion/Run0/Run0.pvd
                 OutputData/Diffusion/Run0/Cycle000001/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a diffusion problem set up from MOOSE and produce the same result as a native run.'
   []
   [./MFEMDiffusionPartial]
@@ -19,6 +21,7 @@
   input = diffusion_partial.i
   xmldiff = 'OutputData/DiffusionPartial/Run0/Run0.pvd
               OutputData/DiffusionPartial/Run0/Cycle000001/proc000000.vtu'
+  ignored_items = "root['VTKFile']['@version']"
   requirement = 'Platypus shall have the ability to solve a diffusion problem with partial assembly set up from MOOSE and produce the same result as a native run.'
   []
   [./MFEMGradDiv]
@@ -26,6 +29,7 @@
   input = graddiv.i
   xmldiff = 'OutputData/GradDiv/Run0/Run0.pvd
               OutputData/GradDiv/Run0/Cycle000001/proc000000.vtu'
+  ignored_items = "root['VTKFile']['@version']"
   requirement = 'Platypus shall have the ability to solve a grad-div problem with Raviart-Thomas elements set up from MOOSE and produce the same result as a native run.'
   []
   [./MFEMHeatConduction]
@@ -34,6 +38,7 @@
     xmldiff = 'OutputData/HeatConduction/Run0/Run0.pvd
                 OutputData/HeatConduction/Run0/Cycle000001/proc000000.vtu
                 OutputData/HeatConduction/Run0/Cycle000004/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a transient heat conduction problem set up from MOOSE and produce the same result as a native run.'
   []
   [./MFEMHeatConductionElement]
@@ -42,6 +47,7 @@
     xmldiff = 'OutputData/HeatConductionElement/Run0/Run0.pvd
                 OutputData/HeatConductionElement/Run0/Cycle000001/proc000000.vtu
                 OutputData/HeatConductionElement/Run0/Cycle000004/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a transient heat conduction problem with element assembly set up from MOOSE and produce the same result as a native run.'
   []
   [./MFEMHeatTransfer]
@@ -49,6 +55,7 @@
     input = heattransfer.i
     xmldiff = 'OutputData/HeatTransfer/Run0/Run0.pvd
                 OutputData/HeatTransfer/Run0/Cycle000003/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a transient heat conduction problem with a heat transfer coefficient on one boundary set up from MOOSE.'
   []
   [./MFEMLinearElasticity]
@@ -56,6 +63,7 @@
     input = linearelasticity.i
     xmldiff = 'OutputData/LinearElasticity/Run0/Run0.pvd
                 OutputData/LinearElasticity/Run0/Cycle000001/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a linear elasticity problem set up from MOOSE and produce the same result as a native run.'
   []
   [./MFEMGravity]
@@ -63,6 +71,7 @@
     input = gravity.i
     xmldiff = 'OutputData/Gravity/Run0/Run0.pvd
                 OutputData/Gravity/Run0/Cycle000001/proc000000.vtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to solve a linear elasticity problem for a beam deformed under gravitational loads.'
   []
   [./MFEMIrrotational]

--- a/test/tests/variables/tests
+++ b/test/tests/variables/tests
@@ -5,6 +5,7 @@
     input = mfem_variables_from_moose.i
     xmldiff = 'OutputData/VariableSetupTest/Run0/Cycle000000/data.pvtu
                 OutputData/VariableSetupTest/Run0/Cycle000001/data.pvtu'
+    ignored_items = "root['VTKFile']['@version']"
     requirement = 'Platypus shall have the ability to add an MFEMVariable from a user specification of a MOOSE variable, inferring the FESpace.'
   []
 []


### PR DESCRIPTION
Alternative solution to #92 for the test failures caused by the VTK version change.
Mostly for information and future reference, feel free to close if not worth it in this repo.
Happy to apply this patch on the MOOSE side instead if deemed appropriate.